### PR TITLE
avoid duplicate file extensions

### DIFF
--- a/xchart-demo/src/main/java/com/xeiam/xchart/standalone/Example1.java
+++ b/xchart-demo/src/main/java/com/xeiam/xchart/standalone/Example1.java
@@ -42,7 +42,7 @@ public class Example1 {
 
     BitmapEncoder.saveBitmap(chart, "./Sample_Chart", BitmapFormat.PNG);
     BitmapEncoder.saveBitmap(chart, "./Sample_Chart", BitmapFormat.JPG);
-    BitmapEncoder.saveJPGWithQuality(chart, "./Sample_Chart_With_Quality", BitmapFormat.JPG, 0.95f);
+    BitmapEncoder.saveJPGWithQuality(chart, "./Sample_Chart_With_Quality.jpg", 0.95f);
     BitmapEncoder.saveBitmap(chart, "./Sample_Chart", BitmapFormat.BMP);
     BitmapEncoder.saveBitmap(chart, "./Sample_Chart", BitmapFormat.GIF);
 

--- a/xchart-demo/src/main/java/com/xeiam/xchart/standalone/Example1.java
+++ b/xchart-demo/src/main/java/com/xeiam/xchart/standalone/Example1.java
@@ -42,7 +42,7 @@ public class Example1 {
 
     BitmapEncoder.saveBitmap(chart, "./Sample_Chart", BitmapFormat.PNG);
     BitmapEncoder.saveBitmap(chart, "./Sample_Chart", BitmapFormat.JPG);
-    BitmapEncoder.saveJPGWithQuality(chart, "./Sample_Chart_With_Quality.jpg", 0.95f);
+    BitmapEncoder.saveJPGWithQuality(chart, "./Sample_Chart_With_Quality", BitmapFormat.JPG, 0.95f);
     BitmapEncoder.saveBitmap(chart, "./Sample_Chart", BitmapFormat.BMP);
     BitmapEncoder.saveBitmap(chart, "./Sample_Chart", BitmapFormat.GIF);
 

--- a/xchart/src/main/java/com/xeiam/xchart/BitmapEncoder.java
+++ b/xchart/src/main/java/com/xeiam/xchart/BitmapEncoder.java
@@ -53,6 +53,23 @@ public final class BitmapEncoder {
   public enum BitmapFormat {
     PNG, JPG, BMP, GIF;
   }
+  
+  /**
+   * Only adds the extension of the BitmapFormat to the filename if the filename doesn't already have it.
+   * 
+   * @param fileName
+   * @param bitmapFormat
+   * @return filename (if extension already exists), otherwise;: filename + "." + extension
+   */
+  private static String addFileExtension(String fileName, BitmapFormat bitmapFormat) {
+	  String fileNameWithFileExtension = fileName;
+	  final String newFileExtension = "." + bitmapFormat.toString().toLowerCase();
+	  if (fileName.length() <= newFileExtension.length() ||
+			  !fileName.substring(fileName.length()-newFileExtension.length(), fileName.length()).equalsIgnoreCase(newFileExtension)) {
+		  fileNameWithFileExtension = fileName + newFileExtension;
+	  }
+	  return fileNameWithFileExtension;
+  }
 
   /**
    * Save a Chart as an image file
@@ -66,7 +83,7 @@ public final class BitmapEncoder {
 
     BufferedImage bufferedImage = getBufferedImage(chart);
 
-    OutputStream out = new FileOutputStream(fileName + "." + bitmapFormat.toString().toLowerCase());
+    OutputStream out = new FileOutputStream(addFileExtension(fileName, bitmapFormat));
     ImageIO.write(bufferedImage, bitmapFormat.toString().toLowerCase(), out);
     out.close();
   }
@@ -108,7 +125,7 @@ public final class BitmapEncoder {
 
       setDPI(metadata, DPI);
 
-      File file = new File(fileName + "." + bitmapFormat.toString().toLowerCase());
+      File file = new File(addFileExtension(fileName, bitmapFormat));
       FileImageOutputStream output = new FileImageOutputStream(file);
       writer.setOutput(output);
       IIOImage image = new IIOImage(bufferedImage, null, metadata);
@@ -150,11 +167,12 @@ public final class BitmapEncoder {
    *
    * @param chart
    * @param fileName
+   * @param bitmapFormat
    * @param quality - a float between 0 and 1 (1 = maximum quality)
    * @throws FileNotFoundException
    * @throws IOException
    */
-  public static void saveJPGWithQuality(Chart chart, String fileName, float quality) throws FileNotFoundException, IOException {
+  public static void saveJPGWithQuality(Chart chart, String fileName, BitmapFormat bitmapFormat, float quality) throws FileNotFoundException, IOException {
 
     BufferedImage bufferedImage = getBufferedImage(chart);
 
@@ -164,7 +182,7 @@ public final class BitmapEncoder {
     ImageWriteParam iwp = writer.getDefaultWriteParam();
     iwp.setCompressionMode(ImageWriteParam.MODE_EXPLICIT);
     iwp.setCompressionQuality(quality);
-    File file = new File(fileName);
+    File file = new File(addFileExtension(fileName, bitmapFormat));
     FileImageOutputStream output = new FileImageOutputStream(file);
     try {
       writer.setOutput(output);

--- a/xchart/src/main/java/com/xeiam/xchart/BitmapEncoder.java
+++ b/xchart/src/main/java/com/xeiam/xchart/BitmapEncoder.java
@@ -61,7 +61,7 @@ public final class BitmapEncoder {
    * @param bitmapFormat
    * @return filename (if extension already exists), otherwise;: filename + "." + extension
    */
-  private static String addFileExtension(String fileName, BitmapFormat bitmapFormat) {
+  public static String addFileExtension(String fileName, BitmapFormat bitmapFormat) {
 	  String fileNameWithFileExtension = fileName;
 	  final String newFileExtension = "." + bitmapFormat.toString().toLowerCase();
 	  if (fileName.length() <= newFileExtension.length() ||
@@ -172,7 +172,7 @@ public final class BitmapEncoder {
    * @throws FileNotFoundException
    * @throws IOException
    */
-  public static void saveJPGWithQuality(Chart chart, String fileName, BitmapFormat bitmapFormat, float quality) throws FileNotFoundException, IOException {
+  public static void saveJPGWithQuality(Chart chart, String fileName, float quality) throws FileNotFoundException, IOException {
 
     BufferedImage bufferedImage = getBufferedImage(chart);
 
@@ -182,7 +182,7 @@ public final class BitmapEncoder {
     ImageWriteParam iwp = writer.getDefaultWriteParam();
     iwp.setCompressionMode(ImageWriteParam.MODE_EXPLICIT);
     iwp.setCompressionQuality(quality);
-    File file = new File(addFileExtension(fileName, bitmapFormat));
+    File file = new File(fileName);
     FileImageOutputStream output = new FileImageOutputStream(file);
     try {
       writer.setOutput(output);

--- a/xchart/src/main/java/com/xeiam/xchart/XChartPanel.java
+++ b/xchart/src/main/java/com/xeiam/xchart/XChartPanel.java
@@ -130,7 +130,7 @@ public class XChartPanel extends JPanel {
           if (fileChooser.getFileFilter() == null) {
             BitmapEncoder.saveBitmap(chart, theFileToSave.getCanonicalPath().toString(), BitmapFormat.PNG);
           } else if (fileChooser.getFileFilter().getDescription().equals("*.jpg,*.JPG")) {
-            BitmapEncoder.saveJPGWithQuality(chart, theFileToSave.getCanonicalPath().toString(), BitmapFormat.JPG, 1.0f);
+            BitmapEncoder.saveJPGWithQuality(chart, BitmapEncoder.addFileExtension(theFileToSave.getCanonicalPath().toString(), BitmapFormat.JPG), 1.0f);
           } else if (fileChooser.getFileFilter().getDescription().equals("*.png,*.PNG")) {
             BitmapEncoder.saveBitmap(chart, theFileToSave.getCanonicalPath().toString(), BitmapFormat.PNG);
           } else if (fileChooser.getFileFilter().getDescription().equals("*.bmp,*.BMP")) {

--- a/xchart/src/main/java/com/xeiam/xchart/XChartPanel.java
+++ b/xchart/src/main/java/com/xeiam/xchart/XChartPanel.java
@@ -130,7 +130,7 @@ public class XChartPanel extends JPanel {
           if (fileChooser.getFileFilter() == null) {
             BitmapEncoder.saveBitmap(chart, theFileToSave.getCanonicalPath().toString(), BitmapFormat.PNG);
           } else if (fileChooser.getFileFilter().getDescription().equals("*.jpg,*.JPG")) {
-            BitmapEncoder.saveJPGWithQuality(chart, theFileToSave.getCanonicalPath().toString() + ".jpg", 1.0f);
+            BitmapEncoder.saveJPGWithQuality(chart, theFileToSave.getCanonicalPath().toString(), BitmapFormat.JPG, 1.0f);
           } else if (fileChooser.getFileFilter().getDescription().equals("*.png,*.PNG")) {
             BitmapEncoder.saveBitmap(chart, theFileToSave.getCanonicalPath().toString(), BitmapFormat.PNG);
           } else if (fileChooser.getFileFilter().getDescription().equals("*.bmp,*.BMP")) {


### PR DESCRIPTION
With the save dialog always adding `"." + bitmapFormat.toString().toLowerCase()` there's one scenario that's unwanted:

1. you save a chart as *chart1* resulting in a file named **chart1.jpg**
2. you want to save another chart
3. you choose/click the existing **chart1.jpg** and edit the name to *chart2.jpg*
4. the result is a file named **chart2.jpg.jpg**

The proposed change avoid adding a file extension where it already exists