### PR TITLE
Fix displaying logarithmic tick labels

### DIFF
--- a/xchart/src/main/java/com/xeiam/xchart/internal/chartpart/AxisTickLogarithmicCalculator.java
+++ b/xchart/src/main/java/com/xeiam/xchart/internal/chartpart/AxisTickLogarithmicCalculator.java
@@ -116,7 +116,8 @@ public class AxisTickLogarithmicCalculator extends AxisTickCalculator {
           tickLabels.add(numberFormatter.formatLogNumber(j, axisDirection));
         }
         else {
-          tickLabels.add(null);
+           // Set a space to avoid Zero length string passed to TextLayout constructor
+          tickLabels.add(" ");
         }
 
         // add all the tick marks though


### PR DESCRIPTION
When activating the logarithmic option on x axis I get:
java.lang.NullPointerException
	at com.xeiam.xchart.internal.chartpart.Axis.getXAxisHeightHint(Axis.java:282)

because the first label is null:
tickLabels[null, null, null, null, null, null, null, null, 0.1, null, null, null, null, null, null, null, null, 1]

I think the best fix is to always fill the labels.