### PR TITLE
BugFix - NPE when plotting small numbers

### DIFF
--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxisTickCalculator_Number.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxisTickCalculator_Number.java
@@ -136,7 +136,8 @@ public class AxisTickCalculator_Number extends AxisTickCalculator_ {
       // System.out.println("gridStepInChartSpace: " + gridStepInChartSpace);
 
       BigDecimal gridStepBigDecimal = BigDecimal.valueOf(gridStep);
-      BigDecimal cleanedGridStep = gridStepBigDecimal.setScale(10, RoundingMode.HALF_UP).stripTrailingZeros(); // chop off any double imprecision
+      int scale = Math.max(10, gridStepBigDecimal.scale());
+      BigDecimal cleanedGridStep = gridStepBigDecimal.setScale(scale, RoundingMode.HALF_UP).stripTrailingZeros(); // chop off any double imprecision
       // System.out.println("cleanedGridStep: " + cleanedGridStep);
       // TODO figure this out. It happens once in a blue moon.
       BigDecimal firstPosition = null;


### PR DESCRIPTION
Before this patch XChart would get an NPE when trying to plot numbers
which are smaller then 1E-10. This happened because gridStep was scaled
using a hard coded 10, zeroing out numbers on smaller scale.
Now we choose the right scale for small numbers and use that.

This fixes a crash when running the following code:

	double[] xData = new double[] { 1.0, 2.0};
	double[] yData = new double[] { 1E-12, 1.1E-12};
	Chart_XY chart = new ChartBuilder_XY().build();
	chart.addSeries("Test", xData, yData);
	new SwingWrapper(chart).displayChart();