### PR TITLE
Comment out printlns for y axis overrides

### DIFF
--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxisPair.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxisPair.java
@@ -163,8 +163,8 @@ public class AxisPair<ST extends AxesChartStyler, S extends Series> implements C
 
           overrideYAxisMaxValue = max;
           overrideYAxisMinValue = min;
-          System.out.println("overrideYAxisMaxValue: " + overrideYAxisMaxValue);
-          System.out.println("overrideYAxisMinValue: " + overrideYAxisMinValue);
+          // System.out.println("overrideYAxisMaxValue: " + overrideYAxisMaxValue);
+          // System.out.println("overrideYAxisMinValue: " + overrideYAxisMinValue);
         }
 
         // override min/max value for bar charts' Y-Axis


### PR DESCRIPTION
Hi there,

First, thanks for a great library!

The new stacked option for category charts which came out in 3.2.1 works fine, but when you resize a chart of this type, a lot of debug information is printed to standard output. I've commented out the offending lines, which seem to resolve this issue.