### PR TITLE
Pluggable rendering

### DIFF
--- a/xchart/src/main/java/org/knowm/xchart/BitmapEncoder.java
+++ b/xchart/src/main/java/org/knowm/xchart/BitmapEncoder.java
@@ -16,6 +16,9 @@
  */
 package org.knowm.xchart;
 
+import org.knowm.xchart.graphics.Java2DGraphics;
+import org.knowm.xchart.internal.chartpart.Chart;
+
 import java.awt.Graphics2D;
 import java.awt.geom.AffineTransform;
 import java.awt.image.BufferedImage;
@@ -36,8 +39,6 @@ import javax.imageio.metadata.IIOInvalidTreeException;
 import javax.imageio.metadata.IIOMetadata;
 import javax.imageio.metadata.IIOMetadataNode;
 import javax.imageio.stream.FileImageOutputStream;
-
-import org.knowm.xchart.internal.chartpart.Chart;
 
 /**
  * A helper class with static methods for saving Charts as bitmaps
@@ -115,7 +116,7 @@ public final class BitmapEncoder {
     at.scale(scaleFactor, scaleFactor);
     graphics2D.setTransform(at);
 
-    chart.paint(graphics2D, chart.getWidth(), chart.getHeight());
+    chart.paint(new Java2DGraphics(graphics2D), chart.getWidth(), chart.getHeight());
     Iterator<ImageWriter> writers = ImageIO.getImageWritersByFormatName(bitmapFormat.toString().toLowerCase());
     if (writers.hasNext()) {
       ImageWriter writer = writers.next();
@@ -176,7 +177,6 @@ public final class BitmapEncoder {
    *
    * @param chart
    * @param fileName
-   * @param bitmapFormat
    * @param quality - a float between 0 and 1 (1 = maximum quality)
    * @throws FileNotFoundException
    * @throws IOException
@@ -231,7 +231,7 @@ public final class BitmapEncoder {
 
     BufferedImage bufferedImage = new BufferedImage(chart.getWidth(), chart.getHeight(), BufferedImage.TYPE_INT_RGB);
     Graphics2D graphics2D = bufferedImage.createGraphics();
-    chart.paint(graphics2D, chart.getWidth(), chart.getHeight());
+    chart.paint(new Java2DGraphics(graphics2D), chart.getWidth(), chart.getHeight());
     return bufferedImage;
   }
 

--- a/xchart/src/main/java/org/knowm/xchart/BubbleChart.java
+++ b/xchart/src/main/java/org/knowm/xchart/BubbleChart.java
@@ -16,13 +16,7 @@
  */
 package org.knowm.xchart;
 
-import java.awt.BasicStroke;
-import java.awt.Color;
-import java.awt.Graphics2D;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
+import org.knowm.xchart.graphics.Graphics;
 import org.knowm.xchart.internal.Utils;
 import org.knowm.xchart.internal.chartpart.AxisPair;
 import org.knowm.xchart.internal.chartpart.Chart;
@@ -33,6 +27,12 @@ import org.knowm.xchart.internal.style.SeriesColorMarkerLineStyleCycler;
 import org.knowm.xchart.style.BubbleStyler;
 import org.knowm.xchart.style.Styler.ChartTheme;
 import org.knowm.xchart.style.Theme;
+
+import java.awt.BasicStroke;
+import java.awt.Color;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 /**
  * @author timmolter
@@ -207,7 +207,7 @@ public class BubbleChart extends Chart<BubbleStyler, BubbleSeries> {
   }
 
   @Override
-  public void paint(Graphics2D g, int width, int height) {
+  public void paint(Graphics g, int width, int height) {
 
     setWidth(width);
     setHeight(height);

--- a/xchart/src/main/java/org/knowm/xchart/CategoryChart.java
+++ b/xchart/src/main/java/org/knowm/xchart/CategoryChart.java
@@ -16,11 +16,7 @@
  */
 package org.knowm.xchart;
 
-import java.awt.Graphics2D;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
+import org.knowm.xchart.graphics.Graphics;
 import org.knowm.xchart.internal.Utils;
 import org.knowm.xchart.internal.chartpart.AxisPair;
 import org.knowm.xchart.internal.chartpart.Chart;
@@ -31,6 +27,10 @@ import org.knowm.xchart.internal.style.SeriesColorMarkerLineStyleCycler;
 import org.knowm.xchart.style.CategoryStyler;
 import org.knowm.xchart.style.Styler.ChartTheme;
 import org.knowm.xchart.style.Theme;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 /**
  * @author timmolter
@@ -259,7 +259,7 @@ public class CategoryChart extends Chart<CategoryStyler, CategorySeries> {
   }
 
   @Override
-  public void paint(Graphics2D g, int width, int height) {
+  public void paint(Graphics g, int width, int height) {
 
     setWidth(width);
     setHeight(height);

--- a/xchart/src/main/java/org/knowm/xchart/Font.java
+++ b/xchart/src/main/java/org/knowm/xchart/Font.java
@@ -1,0 +1,35 @@
+package org.knowm.xchart;
+
+public class Font {
+  public static final String DIALOG = "Dialog";
+  public static final String DIALOG_INPUT = "DialogInput";
+  public static final String SANS_SERIF = "SansSerif";
+  public static final String SERIF = "Serif";
+  public static final String MONOSPACED = "Monospaced";
+
+  public static final int PLAIN = 0;
+  public static final int BOLD = 1;
+  public static final int ITALIC = 2;
+
+  private final String name;
+  private final int style;
+  private final int size;
+
+  public Font(String name, int style, int size) {
+    this.name = name;
+    this.style = style;
+    this.size = size;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public int getStyle() {
+    return style;
+  }
+
+  public int getSize() {
+    return size;
+  }
+}

--- a/xchart/src/main/java/org/knowm/xchart/PieChart.java
+++ b/xchart/src/main/java/org/knowm/xchart/PieChart.java
@@ -16,9 +16,7 @@
  */
 package org.knowm.xchart;
 
-import java.awt.Graphics2D;
-import java.util.Map;
-
+import org.knowm.xchart.graphics.Graphics;
 import org.knowm.xchart.internal.Series;
 import org.knowm.xchart.internal.chartpart.Chart;
 import org.knowm.xchart.internal.chartpart.Legend_Pie;
@@ -28,6 +26,8 @@ import org.knowm.xchart.internal.style.SeriesColorMarkerLineStyleCycler;
 import org.knowm.xchart.style.PieStyler;
 import org.knowm.xchart.style.Styler.ChartTheme;
 import org.knowm.xchart.style.Theme;
+
+import java.util.Map;
 
 /**
  * @author timmolter
@@ -122,7 +122,7 @@ public class PieChart extends Chart<PieStyler, PieSeries> {
   }
 
   @Override
-  public void paint(Graphics2D g, int width, int height) {
+  public void paint(Graphics g, int width, int height) {
 
     setWidth(width);
     setHeight(height);

--- a/xchart/src/main/java/org/knowm/xchart/VectorGraphicsEncoder.java
+++ b/xchart/src/main/java/org/knowm/xchart/VectorGraphicsEncoder.java
@@ -16,15 +16,16 @@
  */
 package org.knowm.xchart;
 
-import java.io.FileOutputStream;
-import java.io.IOException;
-
-import org.knowm.xchart.internal.chartpart.Chart;
-
 import de.erichseifert.vectorgraphics2d.EPSGraphics2D;
 import de.erichseifert.vectorgraphics2d.PDFGraphics2D;
 import de.erichseifert.vectorgraphics2d.ProcessingPipeline;
 import de.erichseifert.vectorgraphics2d.SVGGraphics2D;
+
+import org.knowm.xchart.graphics.Java2DGraphics;
+import org.knowm.xchart.internal.chartpart.Chart;
+
+import java.io.FileOutputStream;
+import java.io.IOException;
 
 /**
  * A helper class with static methods for saving Charts as bitmaps
@@ -63,7 +64,7 @@ public final class VectorGraphicsEncoder {
       break;
     }
 
-    chart.paint(g, chart.getWidth(), chart.getHeight());
+    chart.paint(new Java2DGraphics(g), chart.getWidth(), chart.getHeight());
 
     // Write the vector graphic output to a file
     FileOutputStream file = new FileOutputStream(fileName + "." + vectorGraphicsFormat.toString().toLowerCase());

--- a/xchart/src/main/java/org/knowm/xchart/XChartPanel.java
+++ b/xchart/src/main/java/org/knowm/xchart/XChartPanel.java
@@ -16,6 +16,11 @@
  */
 package org.knowm.xchart;
 
+import org.knowm.xchart.BitmapEncoder.BitmapFormat;
+import org.knowm.xchart.VectorGraphicsEncoder.VectorGraphicsFormat;
+import org.knowm.xchart.graphics.Java2DGraphics;
+import org.knowm.xchart.internal.chartpart.Chart;
+
 import java.awt.Dimension;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
@@ -28,17 +33,8 @@ import java.awt.event.MouseListener;
 import java.io.File;
 import java.io.IOException;
 
-import javax.swing.AbstractAction;
-import javax.swing.JFileChooser;
-import javax.swing.JMenuItem;
-import javax.swing.JPanel;
-import javax.swing.JPopupMenu;
-import javax.swing.KeyStroke;
+import javax.swing.*;
 import javax.swing.filechooser.FileFilter;
-
-import org.knowm.xchart.BitmapEncoder.BitmapFormat;
-import org.knowm.xchart.VectorGraphicsEncoder.VectorGraphicsFormat;
-import org.knowm.xchart.internal.chartpart.Chart;
 
 /**
  * A Swing JPanel that contains a Chart
@@ -104,7 +100,7 @@ public class XChartPanel<T extends Chart> extends JPanel {
     super.paintComponent(g);
 
     Graphics2D g2d = (Graphics2D) g.create();
-    chart.paint(g2d, getWidth(), getHeight());
+    chart.paint(new Java2DGraphics(g2d), getWidth(), getHeight());
     g2d.dispose();
   }
 

--- a/xchart/src/main/java/org/knowm/xchart/XYChart.java
+++ b/xchart/src/main/java/org/knowm/xchart/XYChart.java
@@ -16,11 +16,7 @@
  */
 package org.knowm.xchart;
 
-import java.awt.Graphics2D;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
+import org.knowm.xchart.graphics.Graphics;
 import org.knowm.xchart.internal.Utils;
 import org.knowm.xchart.internal.chartpart.AxisPair;
 import org.knowm.xchart.internal.chartpart.Chart;
@@ -31,6 +27,10 @@ import org.knowm.xchart.internal.style.SeriesColorMarkerLineStyleCycler;
 import org.knowm.xchart.style.Styler.ChartTheme;
 import org.knowm.xchart.style.Theme;
 import org.knowm.xchart.style.XYStyler;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 /**
  * @author timmolter
@@ -260,7 +260,7 @@ public class XYChart extends Chart<XYStyler, XYSeries> {
   }
 
   @Override
-  public void paint(Graphics2D g, int width, int height) {
+  public void paint(Graphics g, int width, int height) {
 
     setWidth(width);
     setHeight(height);

--- a/xchart/src/main/java/org/knowm/xchart/font/FontFactory.java
+++ b/xchart/src/main/java/org/knowm/xchart/font/FontFactory.java
@@ -1,0 +1,7 @@
+package org.knowm.xchart.font;
+
+import org.knowm.xchart.Font;
+
+public interface FontFactory<T> {
+  T get(Font font);
+}

--- a/xchart/src/main/java/org/knowm/xchart/font/Java2DFontFactory.java
+++ b/xchart/src/main/java/org/knowm/xchart/font/Java2DFontFactory.java
@@ -1,0 +1,10 @@
+package org.knowm.xchart.font;
+
+import org.knowm.xchart.Font;
+
+public class Java2DFontFactory implements FontFactory<java.awt.Font> {
+  @Override
+  public java.awt.Font get(Font font) {
+    return new java.awt.Font(font.getName(), font.getStyle(), font.getSize());
+  }
+}

--- a/xchart/src/main/java/org/knowm/xchart/font/Java2DTextLayout.java
+++ b/xchart/src/main/java/org/knowm/xchart/font/Java2DTextLayout.java
@@ -1,0 +1,24 @@
+package org.knowm.xchart.font;
+
+import java.awt.Shape;
+import java.awt.font.FontRenderContext;
+import java.awt.geom.AffineTransform;
+import java.awt.geom.Rectangle2D;
+
+public class Java2DTextLayout implements TextLayout {
+  private final java.awt.font.TextLayout textLayout;
+
+  public Java2DTextLayout(String text, java.awt.Font font, FontRenderContext frc) {
+    this.textLayout = new java.awt.font.TextLayout(text, font, frc);
+  }
+
+  @Override
+  public Rectangle2D getBounds() {
+    return textLayout.getBounds();
+  }
+
+  @Override
+  public Shape getOutline(AffineTransform transform) {
+    return textLayout.getOutline(transform);
+  }
+}

--- a/xchart/src/main/java/org/knowm/xchart/font/TextLayout.java
+++ b/xchart/src/main/java/org/knowm/xchart/font/TextLayout.java
@@ -1,0 +1,10 @@
+package org.knowm.xchart.font;
+
+import java.awt.Shape;
+import java.awt.geom.AffineTransform;
+import java.awt.geom.Rectangle2D;
+
+public interface TextLayout {
+  Rectangle2D getBounds();
+  Shape getOutline(AffineTransform transform);
+}

--- a/xchart/src/main/java/org/knowm/xchart/graphics/Graphics.java
+++ b/xchart/src/main/java/org/knowm/xchart/graphics/Graphics.java
@@ -1,0 +1,27 @@
+package org.knowm.xchart.graphics;
+
+import org.knowm.xchart.Font;
+import org.knowm.xchart.font.TextLayout;
+
+import java.awt.Color;
+import java.awt.Shape;
+import java.awt.Stroke;
+import java.awt.geom.AffineTransform;
+
+public interface Graphics {
+  void setColor(Color color);
+  void setStroke(Stroke stroke);
+  void setFont(Font font);
+  void setClip(Shape clip);
+
+  TextLayout getTextLayout(String text, Font font);
+  RenderContext getRenderContext();
+
+  AffineTransform getTransform();
+  void setTransform(AffineTransform transform);
+  void transform(AffineTransform transform);
+
+  void fill(Shape shape);
+  void draw(Shape shape);
+  void drawLine(int x1, int y1, int x2, int y2);
+}

--- a/xchart/src/main/java/org/knowm/xchart/graphics/Java2DGraphics.java
+++ b/xchart/src/main/java/org/knowm/xchart/graphics/Java2DGraphics.java
@@ -1,0 +1,83 @@
+package org.knowm.xchart.graphics;
+
+import org.knowm.xchart.Font;
+import org.knowm.xchart.font.FontFactory;
+import org.knowm.xchart.font.Java2DFontFactory;
+import org.knowm.xchart.font.TextLayout;
+
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.RenderingHints;
+import java.awt.Shape;
+import java.awt.Stroke;
+import java.awt.geom.AffineTransform;
+
+public class Java2DGraphics implements Graphics {
+  private final Graphics2D g;
+  private final FontFactory<java.awt.Font> fontFactory = new Java2DFontFactory();
+
+  public Java2DGraphics(Graphics2D g2d) {
+    this.g = g2d;
+    g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON); // global rendering hint
+  }
+
+  @Override
+  public void setColor(Color color) {
+    g.setColor(color);
+  }
+
+  @Override
+  public void setStroke(Stroke stroke) {
+    g.setStroke(stroke);
+  }
+
+  @Override
+  public void fill(Shape shape) {
+    g.fill(shape);
+  }
+
+  @Override
+  public void draw(Shape shape) {
+    g.draw(shape);
+  }
+
+  @Override
+  public AffineTransform getTransform() {
+    return g.getTransform();
+  }
+
+  @Override
+  public void setTransform(AffineTransform transform) {
+    g.setTransform(transform);
+  }
+
+  @Override
+  public void transform(AffineTransform transform) {
+    g.transform(transform);
+  }
+
+  @Override
+  public void setFont(Font font) {
+    g.setFont(fontFactory.get(font));
+  }
+
+  @Override
+  public void drawLine(int x1, int y1, int x2, int y2) {
+    g.drawLine(x1, y1, x2, y2);
+  }
+
+  @Override
+  public void setClip(Shape clip) {
+    g.setClip(clip);
+  }
+
+  @Override
+  public RenderContext getRenderContext() {
+    return new Java2DRenderContext(fontFactory);
+  }
+
+  @Override
+  public TextLayout getTextLayout(String text, Font font) {
+    return getRenderContext().getTextLayout(text, font);
+  }
+}

--- a/xchart/src/main/java/org/knowm/xchart/graphics/Java2DRenderContext.java
+++ b/xchart/src/main/java/org/knowm/xchart/graphics/Java2DRenderContext.java
@@ -1,0 +1,21 @@
+package org.knowm.xchart.graphics;
+
+import org.knowm.xchart.Font;
+import org.knowm.xchart.font.FontFactory;
+import org.knowm.xchart.font.Java2DTextLayout;
+import org.knowm.xchart.font.TextLayout;
+
+import java.awt.font.FontRenderContext;
+
+public class Java2DRenderContext implements RenderContext {
+  private final FontFactory<java.awt.Font> fontFactory;
+
+  Java2DRenderContext(FontFactory<java.awt.Font> fontFactory) {
+    this.fontFactory = fontFactory;
+  }
+
+  @Override
+  public TextLayout getTextLayout(String text, Font font) {
+    return new Java2DTextLayout(text, fontFactory.get(font), new FontRenderContext(null, true, false));
+  }
+}

--- a/xchart/src/main/java/org/knowm/xchart/graphics/RenderContext.java
+++ b/xchart/src/main/java/org/knowm/xchart/graphics/RenderContext.java
@@ -1,0 +1,8 @@
+package org.knowm.xchart.graphics;
+
+import org.knowm.xchart.Font;
+import org.knowm.xchart.font.TextLayout;
+
+public interface RenderContext {
+  TextLayout getTextLayout(String text, Font font);
+}

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Axis.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Axis.java
@@ -16,19 +16,19 @@
  */
 package org.knowm.xchart.internal.chartpart;
 
-import java.awt.Graphics2D;
-import java.awt.Shape;
-import java.awt.font.FontRenderContext;
-import java.awt.font.TextLayout;
-import java.awt.geom.AffineTransform;
-import java.awt.geom.Rectangle2D;
-import java.util.List;
-
+import org.knowm.xchart.font.TextLayout;
+import org.knowm.xchart.graphics.Graphics;
+import org.knowm.xchart.graphics.RenderContext;
 import org.knowm.xchart.internal.Series;
 import org.knowm.xchart.internal.Series_AxesChart;
 import org.knowm.xchart.style.AxesChartStyler;
 import org.knowm.xchart.style.CategoryStyler;
 import org.knowm.xchart.style.Styler.LegendPosition;
+
+import java.awt.Shape;
+import java.awt.geom.AffineTransform;
+import java.awt.geom.Rectangle2D;
+import java.util.List;
 
 /**
  * Axis
@@ -122,7 +122,7 @@ public class Axis<ST extends AxesChartStyler, S extends Series> implements Chart
   }
 
   @Override
-  public void paint(Graphics2D g) {
+  public void paint(Graphics g) {
 
     bounds = new Rectangle2D.Double();
 
@@ -139,7 +139,7 @@ public class Axis<ST extends AxesChartStyler, S extends Series> implements Chart
       double xOffset = stylerAxesChart.getChartPadding();
       // double yOffset = chart.getChartTitle().getBounds().getHeight() < .1 ? stylerAxesChart.getChartPadding() : chart.getChartTitle().getBounds().getHeight()
       // + stylerAxesChart.getChartPadding();
-      double yOffset = chart.getChartTitle().getBounds().getHeight() + stylerAxesChart.getChartPadding();
+      double yOffset = chart.getChartTitle().getBounds(g.getRenderContext()).getHeight() + stylerAxesChart.getChartPadding();
 
       /////////////////////////
       int i = 1; // just twice through is all it takes
@@ -154,7 +154,7 @@ public class Axis<ST extends AxesChartStyler, S extends Series> implements Chart
 
                 - width // y-axis approx. width
 
-                - (stylerAxesChart.getLegendPosition() == LegendPosition.OutsideE ? chart.getLegend().getBounds().getWidth() : 0)
+                - (stylerAxesChart.getLegendPosition() == LegendPosition.OutsideE ? chart.getLegend().getBounds(g.getRenderContext()).getWidth() : 0)
 
                 - 2 * stylerAxesChart.getChartPadding()
 
@@ -164,9 +164,9 @@ public class Axis<ST extends AxesChartStyler, S extends Series> implements Chart
 
         ;
 
-        height = chart.getHeight() - yOffset - chart.getXAxis().getXAxisHeightHint(approximateXAxisWidth) - stylerAxesChart.getPlotMargin() - stylerAxesChart.getChartPadding();
+        height = chart.getHeight() - yOffset - chart.getXAxis().getXAxisHeightHint(g.getRenderContext(), approximateXAxisWidth) - stylerAxesChart.getPlotMargin() - stylerAxesChart.getChartPadding();
 
-        width = getYAxisWidthHint(height);
+        width = getYAxisWidthHint(g.getRenderContext(), height);
         // System.out.println("width after: " + width);
 
         // System.out.println("height: " + height);
@@ -184,7 +184,7 @@ public class Axis<ST extends AxesChartStyler, S extends Series> implements Chart
       axisTick.paint(g);
 
       // now we know the real bounds width after ticks and title are painted
-      width = (stylerAxesChart.isYAxisTitleVisible() ? axisTitle.getBounds().getWidth() : 0) + axisTick.getBounds().getWidth();
+      width = (stylerAxesChart.isYAxisTitleVisible() ? axisTitle.getBounds(g.getRenderContext()).getWidth() : 0) + axisTick.getBounds(g.getRenderContext()).getWidth();
 
       bounds = new Rectangle2D.Double(xOffset, yOffset, width, height);
       // g.setColor(Color.yellow);
@@ -196,16 +196,16 @@ public class Axis<ST extends AxesChartStyler, S extends Series> implements Chart
       // calculate paint zone
       // |____________________|
 
-      double xOffset = chart.getYAxis().getBounds().getWidth() + (stylerAxesChart.isYAxisTicksVisible() ? stylerAxesChart.getPlotMargin() : 0) + stylerAxesChart.getChartPadding();
-      double yOffset = chart.getYAxis().getBounds().getY() + chart.getYAxis().getBounds().getHeight() + stylerAxesChart.getPlotMargin();
+      double xOffset = chart.getYAxis().getBounds(g.getRenderContext()).getWidth() + (stylerAxesChart.isYAxisTicksVisible() ? stylerAxesChart.getPlotMargin() : 0) + stylerAxesChart.getChartPadding();
+      double yOffset = chart.getYAxis().getBounds(g.getRenderContext()).getY() + chart.getYAxis().getBounds(g.getRenderContext()).getHeight() + stylerAxesChart.getPlotMargin();
 
       double width =
 
           chart.getWidth()
 
-              - chart.getYAxis().getBounds().getWidth() // y-axis was already painted
+              - chart.getYAxis().getBounds(g.getRenderContext()).getWidth() // y-axis was already painted
 
-              - (stylerAxesChart.getLegendPosition() == LegendPosition.OutsideE ? chart.getLegend().getBounds().getWidth() : 0)
+              - (stylerAxesChart.getLegendPosition() == LegendPosition.OutsideE ? chart.getLegend().getBounds(g.getRenderContext()).getWidth() : 0)
 
               - 2 * stylerAxesChart.getChartPadding()
 
@@ -218,7 +218,7 @@ public class Axis<ST extends AxesChartStyler, S extends Series> implements Chart
       // double height = this.getXAxisHeightHint(width);
       // System.out.println("height: " + height);
       // the Y-Axis was already draw at this point so we know how much vertical room is left for the X-Axis
-      double height = chart.getHeight() - chart.getYAxis().getBounds().getY() - chart.getYAxis().getBounds().getHeight() - stylerAxesChart.getChartPadding() - stylerAxesChart.getPlotMargin();
+      double height = chart.getHeight() - chart.getYAxis().getBounds(g.getRenderContext()).getY() - chart.getYAxis().getBounds(g.getRenderContext()).getHeight() - stylerAxesChart.getChartPadding() - stylerAxesChart.getPlotMargin();
       // System.out.println("height2: " + height2);
 
       bounds = new Rectangle2D.Double(xOffset, yOffset, width, height);
@@ -226,7 +226,7 @@ public class Axis<ST extends AxesChartStyler, S extends Series> implements Chart
       // g.draw(bounds);
 
       // now paint the X-Axis given the above paint zone
-      this.axisTickCalculator = getAxisTickCalculator(bounds.getWidth());
+      this.axisTickCalculator = getAxisTickCalculator(g.getRenderContext(), bounds.getWidth());
       axisTitle.paint(g);
       axisTick.paint(g);
 
@@ -239,17 +239,17 @@ public class Axis<ST extends AxesChartStyler, S extends Series> implements Chart
    *
    * @return
    */
-  private double getXAxisHeightHint(double workingSpace) {
+  private double getXAxisHeightHint(RenderContext rc, double workingSpace) {
 
     // Axis title
     double titleHeight = 0.0;
     if (chart.getXAxisTitle() != null && !chart.getXAxisTitle().trim().equalsIgnoreCase("") && stylerAxesChart.isXAxisTitleVisible()) {
-      TextLayout textLayout = new TextLayout(chart.getXAxisTitle(), stylerAxesChart.getAxisTitleFont(), new FontRenderContext(null, true, false));
+      TextLayout textLayout = rc.getTextLayout(chart.getXAxisTitle(), stylerAxesChart.getAxisTitleFont());
       Rectangle2D rectangle = textLayout.getBounds();
       titleHeight = rectangle.getHeight() + stylerAxesChart.getAxisTitlePadding();
     }
 
-    this.axisTickCalculator = getAxisTickCalculator(workingSpace);
+    this.axisTickCalculator = getAxisTickCalculator(rc, workingSpace);
 
     // Axis tick labels
     double axisTickLabelsHeight = 0.0;
@@ -270,7 +270,7 @@ public class Axis<ST extends AxesChartStyler, S extends Series> implements Chart
       // System.out.println("sampleLabel: " + sampleLabel);
 
       // get the height of the label including rotation
-      TextLayout textLayout = new TextLayout(sampleLabel.length() == 0 ? " " : sampleLabel, stylerAxesChart.getAxisTickLabelsFont(), new FontRenderContext(null, true, false));
+      TextLayout textLayout = rc.getTextLayout(sampleLabel.length() == 0 ? " " : sampleLabel, stylerAxesChart.getAxisTickLabelsFont());
       AffineTransform rot = stylerAxesChart.getXAxisLabelRotation() == 0 ? null : AffineTransform.getRotateInstance(-1 * Math.toRadians(stylerAxesChart.getXAxisLabelRotation()));
       Shape shape = textLayout.getOutline(rot);
       Rectangle2D rectangle = shape.getBounds();
@@ -280,17 +280,17 @@ public class Axis<ST extends AxesChartStyler, S extends Series> implements Chart
     return titleHeight + axisTickLabelsHeight;
   }
 
-  private double getYAxisWidthHint(double workingSpace) {
+  private double getYAxisWidthHint(RenderContext rc, double workingSpace) {
 
     // Axis title
     double titleHeight = 0.0;
     if (chart.getyYAxisTitle() != null && !chart.getyYAxisTitle().trim().equalsIgnoreCase("") && stylerAxesChart.isYAxisTitleVisible()) {
-      TextLayout textLayout = new TextLayout(chart.getyYAxisTitle(), stylerAxesChart.getAxisTitleFont(), new FontRenderContext(null, true, false));
+      TextLayout textLayout = rc.getTextLayout(chart.getyYAxisTitle(), stylerAxesChart.getAxisTitleFont());
       Rectangle2D rectangle = textLayout.getBounds();
       titleHeight = rectangle.getHeight() + stylerAxesChart.getAxisTitlePadding();
     }
 
-    this.axisTickCalculator = getAxisTickCalculator(workingSpace);
+    this.axisTickCalculator = getAxisTickCalculator(rc, workingSpace);
 
     // Axis tick labels
     double axisTickLabelsHeight = 0.0;
@@ -309,7 +309,7 @@ public class Axis<ST extends AxesChartStyler, S extends Series> implements Chart
       }
 
       // get the height of the label including rotation
-      TextLayout textLayout = new TextLayout(sampleLabel.length() == 0 ? " " : sampleLabel, stylerAxesChart.getAxisTickLabelsFont(), new FontRenderContext(null, true, false));
+      TextLayout textLayout = rc.getTextLayout(sampleLabel.length() == 0 ? " " : sampleLabel, stylerAxesChart.getAxisTickLabelsFont());
       Rectangle2D rectangle = textLayout.getBounds();
 
       axisTickLabelsHeight = rectangle.getWidth() + stylerAxesChart.getAxisTickPadding() + stylerAxesChart.getAxisTickMarkLength();
@@ -317,7 +317,7 @@ public class Axis<ST extends AxesChartStyler, S extends Series> implements Chart
     return titleHeight + axisTickLabelsHeight;
   }
 
-  private AxisTickCalculator_ getAxisTickCalculator(double workingSpace) {
+  private AxisTickCalculator_ getAxisTickCalculator(RenderContext rc, double workingSpace) {
 
     // X-Axis
     if (getDirection() == Direction.X) {
@@ -331,14 +331,14 @@ public class Axis<ST extends AxesChartStyler, S extends Series> implements Chart
       }
       else if (getAxisDataType() == AxisDataType.Date) {
 
-        return new AxisTickCalculator_Date(getDirection(), workingSpace, min, max, stylerAxesChart);
+        return new AxisTickCalculator_Date(rc, getDirection(), workingSpace, min, max, stylerAxesChart);
       }
       else if (stylerAxesChart.isXAxisLogarithmic()) {
 
         return new AxisTickCalculator_Logarithmic(getDirection(), workingSpace, min, max, stylerAxesChart);
       }
       else {
-        return new AxisTickCalculator_Number(getDirection(), workingSpace, min, max, stylerAxesChart);
+        return new AxisTickCalculator_Number(rc, getDirection(), workingSpace, min, max, stylerAxesChart);
 
       }
     }
@@ -351,7 +351,7 @@ public class Axis<ST extends AxesChartStyler, S extends Series> implements Chart
         return new AxisTickCalculator_Logarithmic(getDirection(), workingSpace, min, max, stylerAxesChart);
       }
       else {
-        return new AxisTickCalculator_Number(getDirection(), workingSpace, min, max, stylerAxesChart);
+        return new AxisTickCalculator_Number(rc, getDirection(), workingSpace, min, max, stylerAxesChart);
 
       }
     }
@@ -414,7 +414,7 @@ public class Axis<ST extends AxesChartStyler, S extends Series> implements Chart
   }
 
   @Override
-  public Rectangle2D getBounds() {
+  public Rectangle2D getBounds(RenderContext rc) {
 
     return bounds;
   }

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxisPair.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxisPair.java
@@ -16,15 +16,16 @@
  */
 package org.knowm.xchart.internal.chartpart;
 
-import java.awt.Graphics2D;
-import java.awt.geom.Rectangle2D;
-import java.util.Iterator;
-
 import org.knowm.xchart.CategorySeries.CategorySeriesRenderStyle;
+import org.knowm.xchart.graphics.Graphics;
+import org.knowm.xchart.graphics.RenderContext;
 import org.knowm.xchart.internal.Series;
 import org.knowm.xchart.internal.Series_AxesChart;
 import org.knowm.xchart.style.AxesChartStyler;
 import org.knowm.xchart.style.CategoryStyler;
+
+import java.awt.geom.Rectangle2D;
+import java.util.Iterator;
 
 /**
  * @author timmolter
@@ -51,7 +52,7 @@ public class AxisPair<ST extends AxesChartStyler, S extends Series> implements C
   }
 
   @Override
-  public void paint(Graphics2D g) {
+  public void paint(Graphics g) {
 
     prepareForPaint();
 
@@ -221,7 +222,7 @@ public class AxisPair<ST extends AxesChartStyler, S extends Series> implements C
   }
 
   @Override
-  public Rectangle2D getBounds() {
+  public Rectangle2D getBounds(RenderContext rc) {
 
     return null; // should never be called
   }

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxisTick.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxisTick.java
@@ -16,13 +16,14 @@
  */
 package org.knowm.xchart.internal.chartpart;
 
-import java.awt.Graphics2D;
-import java.awt.geom.Rectangle2D;
-
+import org.knowm.xchart.graphics.Graphics;
+import org.knowm.xchart.graphics.RenderContext;
 import org.knowm.xchart.internal.Series;
 import org.knowm.xchart.internal.Series_AxesChart;
 import org.knowm.xchart.internal.chartpart.Axis.Direction;
 import org.knowm.xchart.style.AxesChartStyler;
+
+import java.awt.geom.Rectangle2D;
 
 /**
  * An axis tick
@@ -54,13 +55,13 @@ public class AxisTick<ST extends AxesChartStyler, S extends Series> implements C
   }
 
   @Override
-  public Rectangle2D getBounds() {
+  public Rectangle2D getBounds(RenderContext rc) {
 
     return bounds;
   }
 
   @Override
-  public void paint(Graphics2D g) {
+  public void paint(Graphics g) {
 
     if (direction == Axis.Direction.Y && chart.getStyler().isYAxisTicksVisible()) {
 
@@ -69,13 +70,13 @@ public class AxisTick<ST extends AxesChartStyler, S extends Series> implements C
 
       bounds = new Rectangle2D.Double(
 
-          axisTickLabels.getBounds().getX(),
+          axisTickLabels.getBounds(g.getRenderContext()).getX(),
 
-          axisTickLabels.getBounds().getY(),
+          axisTickLabels.getBounds(g.getRenderContext()).getY(),
 
-          axisTickLabels.getBounds().getWidth() + chart.getStyler().getAxisTickPadding() + axisTickMarks.getBounds().getWidth(),
+          axisTickLabels.getBounds(g.getRenderContext()).getWidth() + chart.getStyler().getAxisTickPadding() + axisTickMarks.getBounds(g.getRenderContext()).getWidth(),
 
-          axisTickMarks.getBounds().getHeight()
+          axisTickMarks.getBounds(g.getRenderContext()).getHeight()
 
       );
 
@@ -90,13 +91,13 @@ public class AxisTick<ST extends AxesChartStyler, S extends Series> implements C
 
       bounds = new Rectangle2D.Double(
 
-          axisTickMarks.getBounds().getX(),
+          axisTickMarks.getBounds(g.getRenderContext()).getX(),
 
-          axisTickMarks.getBounds().getY(),
+          axisTickMarks.getBounds(g.getRenderContext()).getY(),
 
-          axisTickLabels.getBounds().getWidth(),
+          axisTickLabels.getBounds(g.getRenderContext()).getWidth(),
 
-          axisTickMarks.getBounds().getHeight() + chart.getStyler().getAxisTickPadding() + axisTickLabels.getBounds().getHeight()
+          axisTickMarks.getBounds(g.getRenderContext()).getHeight() + chart.getStyler().getAxisTickPadding() + axisTickLabels.getBounds(g.getRenderContext()).getHeight()
 
       );
 

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxisTickCalculator_.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxisTickCalculator_.java
@@ -16,16 +16,16 @@
  */
 package org.knowm.xchart.internal.chartpart;
 
+import org.knowm.xchart.font.TextLayout;
+import org.knowm.xchart.graphics.RenderContext;
+import org.knowm.xchart.internal.chartpart.Axis.Direction;
+import org.knowm.xchart.style.AxesChartStyler;
+
 import java.awt.Shape;
-import java.awt.font.FontRenderContext;
-import java.awt.font.TextLayout;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.Rectangle2D;
 import java.util.LinkedList;
 import java.util.List;
-
-import org.knowm.xchart.internal.chartpart.Axis.Direction;
-import org.knowm.xchart.style.AxesChartStyler;
 
 /**
  * @author timmolter
@@ -97,7 +97,7 @@ public abstract class AxisTickCalculator_ {
    * @param tickSpacingHint
    * @return
    */
-  boolean willLabelsFitInTickSpaceHint(List<String> tickLabels, int tickSpacingHint) {
+  boolean willLabelsFitInTickSpaceHint(RenderContext rc, List<String> tickLabels, int tickSpacingHint) {
 
     // Assume that for Y-Axis the ticks will all fit based on their tickSpace hint because the text is usually horizontal and "short". This more applies to the X-Axis.
     if (this.axisDirection == Direction.Y) {
@@ -113,7 +113,7 @@ public abstract class AxisTickCalculator_ {
     }
     // System.out.println("longestLabel: " + sampleLabel);
 
-    TextLayout textLayout = new TextLayout(sampleLabel, styler.getAxisTickLabelsFont(), new FontRenderContext(null, true, false));
+    TextLayout textLayout = rc.getTextLayout(sampleLabel, styler.getAxisTickLabelsFont());
     AffineTransform rot = styler.getXAxisLabelRotation() == 0 ? null : AffineTransform.getRotateInstance(-1 * Math.toRadians(styler.getXAxisLabelRotation()));
     Shape shape = textLayout.getOutline(rot);
     Rectangle2D rectangle = shape.getBounds();

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxisTickCalculator_Date.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxisTickCalculator_Date.java
@@ -16,14 +16,16 @@
  */
 package org.knowm.xchart.internal.chartpart;
 
+import org.knowm.xchart.graphics.Graphics;
+import org.knowm.xchart.graphics.RenderContext;
+import org.knowm.xchart.internal.Utils;
+import org.knowm.xchart.internal.chartpart.Axis.Direction;
+import org.knowm.xchart.style.AxesChartStyler;
+
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-
-import org.knowm.xchart.internal.Utils;
-import org.knowm.xchart.internal.chartpart.Axis.Direction;
-import org.knowm.xchart.style.AxesChartStyler;
 
 /**
  * This class encapsulates the logic to generate the axis tick mark and axis tick label data for rendering the axis ticks for date axes
@@ -108,14 +110,14 @@ public class AxisTickCalculator_Date extends AxisTickCalculator_ {
    * @param maxValue
    * @param styler
    */
-  public AxisTickCalculator_Date(Direction axisDirection, double workingSpace, double minValue, double maxValue, AxesChartStyler styler) {
+  public AxisTickCalculator_Date(final RenderContext rc, Direction axisDirection, double workingSpace, double minValue, double maxValue, AxesChartStyler styler) {
 
     super(axisDirection, workingSpace, minValue, maxValue, styler);
 
-    calculate();
+    calculate(rc);
   }
 
-  private void calculate() {
+  private void calculate(final RenderContext rc) {
 
     // tick space - a percentage of the working space available for ticks
     double tickSpace = styler.getPlotContentSize() * workingSpace; // in plot space
@@ -211,7 +213,7 @@ public class AxisTickCalculator_Date extends AxisTickCalculator_ {
         tickLocations.add(tickLabelPosition);
         // }
       }
-    } while (!willLabelsFitInTickSpaceHint(tickLabels, gridStepInChartSpace));
+    } while (!willLabelsFitInTickSpaceHint(rc, tickLabels, gridStepInChartSpace));
   }
 
   static class TimeSpan {

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxisTickCalculator_Number.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxisTickCalculator_Number.java
@@ -16,13 +16,15 @@
  */
 package org.knowm.xchart.internal.chartpart;
 
-import java.math.BigDecimal;
-import java.math.MathContext;
-import java.math.RoundingMode;
-
+import org.knowm.xchart.graphics.Graphics;
+import org.knowm.xchart.graphics.RenderContext;
 import org.knowm.xchart.internal.Utils;
 import org.knowm.xchart.internal.chartpart.Axis.Direction;
 import org.knowm.xchart.style.AxesChartStyler;
+
+import java.math.BigDecimal;
+import java.math.MathContext;
+import java.math.RoundingMode;
 
 /**
  * This class encapsulates the logic to generate the axis tick mark and axis tick label data for rendering the axis ticks for decimal axes
@@ -42,14 +44,14 @@ public class AxisTickCalculator_Number extends AxisTickCalculator_ {
    * @param maxValue
    * @param styler
    */
-  public AxisTickCalculator_Number(Direction axisDirection, double workingSpace, double minValue, double maxValue, AxesChartStyler styler) {
+  public AxisTickCalculator_Number(final RenderContext rc, Direction axisDirection, double workingSpace, double minValue, double maxValue, AxesChartStyler styler) {
 
     super(axisDirection, workingSpace, minValue, maxValue, styler);
     numberFormatter = new NumberFormatter(styler);
-    calculate();
+    calculate(rc);
   }
 
-  private void calculate() {
+  private void calculate(final RenderContext rc) {
 
     // a check if all axis data are the exact same values
     if (minValue == maxValue) {
@@ -182,7 +184,7 @@ public class AxisTickCalculator_Number extends AxisTickCalculator_ {
         tickLocations.add(tickLabelPosition);
         // }
       }
-    } while (!willLabelsFitInTickSpaceHint(tickLabels, gridStepInChartSpace));
+    } while (!willLabelsFitInTickSpaceHint(rc, tickLabels, gridStepInChartSpace));
 
   }
 

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxisTickLabels.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxisTickLabels.java
@@ -16,19 +16,19 @@
  */
 package org.knowm.xchart.internal.chartpart;
 
-import java.awt.Graphics2D;
-import java.awt.Shape;
-import java.awt.font.FontRenderContext;
-import java.awt.font.TextLayout;
-import java.awt.geom.AffineTransform;
-import java.awt.geom.Rectangle2D;
-import java.util.HashMap;
-import java.util.Map;
-
+import org.knowm.xchart.font.TextLayout;
+import org.knowm.xchart.graphics.Graphics;
+import org.knowm.xchart.graphics.RenderContext;
 import org.knowm.xchart.internal.Series;
 import org.knowm.xchart.internal.Series_AxesChart;
 import org.knowm.xchart.internal.chartpart.Axis.Direction;
 import org.knowm.xchart.style.AxesChartStyler;
+
+import java.awt.Shape;
+import java.awt.geom.AffineTransform;
+import java.awt.geom.Rectangle2D;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Axis tick labels
@@ -52,7 +52,7 @@ public class AxisTickLabels<ST extends AxesChartStyler, S extends Series> implem
   }
 
   @Override
-  public void paint(Graphics2D g) {
+  public void paint(Graphics g) {
 
     g.setFont(chart.getStyler().getAxisTickLabelsFont());
 
@@ -60,10 +60,10 @@ public class AxisTickLabels<ST extends AxesChartStyler, S extends Series> implem
 
     if (direction == Axis.Direction.Y && chart.getStyler().isYAxisTicksVisible()) { // Y-Axis
 
-      double xWidth = chart.getYAxis().getAxisTitle().getBounds().getWidth();
-      double xOffset = chart.getYAxis().getAxisTitle().getBounds().getX() + xWidth;
-      double yOffset = chart.getYAxis().getBounds().getY();
-      double height = chart.getYAxis().getBounds().getHeight();
+      double xWidth = chart.getYAxis().getAxisTitle().getBounds(g.getRenderContext()).getWidth();
+      double xOffset = chart.getYAxis().getAxisTitle().getBounds(g.getRenderContext()).getX() + xWidth;
+      double yOffset = chart.getYAxis().getBounds(g.getRenderContext()).getY();
+      double height = chart.getYAxis().getBounds(g.getRenderContext()).getHeight();
       double maxTickLabelWidth = 0;
       Map<Double, TextLayout> axisLabelTextLayouts = new HashMap<Double, TextLayout>();
 
@@ -75,8 +75,7 @@ public class AxisTickLabels<ST extends AxesChartStyler, S extends Series> implem
         double flippedTickLocation = yOffset + height - tickLocation;
 
         if (tickLabel != null && flippedTickLocation > yOffset && flippedTickLocation < yOffset + height) { // some are null for logarithmic axes
-          FontRenderContext frc = g.getFontRenderContext();
-          TextLayout axisLabelTextLayout = new TextLayout(tickLabel, chart.getStyler().getAxisTickLabelsFont(), frc);
+          TextLayout axisLabelTextLayout = g.getTextLayout(tickLabel, chart.getStyler().getAxisTickLabelsFont());
           Rectangle2D tickLabelBounds = axisLabelTextLayout.getBounds();
           double boundWidth = tickLabelBounds.getWidth();
           if (boundWidth > maxTickLabelWidth) {
@@ -125,9 +124,9 @@ public class AxisTickLabels<ST extends AxesChartStyler, S extends Series> implem
     // X-Axis
     else if (direction == Axis.Direction.X && chart.getStyler().isXAxisTicksVisible()) {
 
-      double xOffset = chart.getXAxis().getBounds().getX();
-      double yOffset = chart.getXAxis().getAxisTitle().getBounds().getY();
-      double width = chart.getXAxis().getBounds().getWidth();
+      double xOffset = chart.getXAxis().getBounds(g.getRenderContext()).getX();
+      double yOffset = chart.getXAxis().getAxisTitle().getBounds(g.getRenderContext()).getY();
+      double width = chart.getXAxis().getBounds(g.getRenderContext()).getWidth();
       double maxTickLabelHeight = 0;
 
       // System.out.println("axisTick.getTickLabels().size(): " + axisTick.getTickLabels().size());
@@ -141,11 +140,10 @@ public class AxisTickLabels<ST extends AxesChartStyler, S extends Series> implem
         // discard null and out of bounds labels
         if (tickLabel != null && shiftedTickLocation > xOffset && shiftedTickLocation < xOffset + width) { // some are null for logarithmic axes
 
-          FontRenderContext frc = g.getFontRenderContext();
-          TextLayout textLayout = new TextLayout(tickLabel, chart.getStyler().getAxisTickLabelsFont(), frc);
-          // System.out.println(textLayout.getOutline(null).getBounds().toString());
+          TextLayout textLayout = g.getTextLayout(tickLabel, chart.getStyler().getAxisTickLabelsFont());
+          // System.out.println(textLayout.getTextOutline(null).getBounds().toString());
 
-          // Shape shape = v.getOutline();
+          // Shape shape = v.getTextOutline();
           AffineTransform rot = AffineTransform.getRotateInstance(-1 * Math.toRadians(chart.getStyler().getXAxisLabelRotation()), 0, 0);
           Shape shape = textLayout.getOutline(rot);
           Rectangle2D tickLabelBounds = shape.getBounds2D();
@@ -202,7 +200,7 @@ public class AxisTickLabels<ST extends AxesChartStyler, S extends Series> implem
   }
 
   @Override
-  public Rectangle2D getBounds() {
+  public Rectangle2D getBounds(RenderContext rc) {
 
     return bounds;
   }

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxisTickMarks.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxisTickMarks.java
@@ -16,15 +16,16 @@
  */
 package org.knowm.xchart.internal.chartpart;
 
-import java.awt.Graphics2D;
-import java.awt.Shape;
-import java.awt.geom.Line2D;
-import java.awt.geom.Rectangle2D;
-
+import org.knowm.xchart.graphics.Graphics;
+import org.knowm.xchart.graphics.RenderContext;
 import org.knowm.xchart.internal.Series;
 import org.knowm.xchart.internal.Series_AxesChart;
 import org.knowm.xchart.internal.chartpart.Axis.Direction;
 import org.knowm.xchart.style.AxesChartStyler;
+
+import java.awt.Shape;
+import java.awt.geom.Line2D;
+import java.awt.geom.Rectangle2D;
 
 /**
  * Axis tick marks. This includes the little tick marks and the line that hugs the plot area.
@@ -48,19 +49,19 @@ public class AxisTickMarks<ST extends AxesChartStyler, S extends Series> impleme
   }
 
   @Override
-  public void paint(Graphics2D g) {
+  public void paint(Graphics g) {
 
     g.setColor(chart.getStyler().getAxisTickMarksColor());
     g.setStroke(chart.getStyler().getAxisTickMarksStroke());
 
     if (direction == Axis.Direction.Y && chart.getStyler().isYAxisTicksVisible()) { // Y-Axis
 
-      double xOffset = chart.getYAxis().getAxisTick().getAxisTickLabels().getBounds().getX() + chart.getYAxis().getAxisTick().getAxisTickLabels().getBounds().getWidth() + chart.getStyler()
+      double xOffset = chart.getYAxis().getAxisTick().getAxisTickLabels().getBounds(g.getRenderContext()).getX() + chart.getYAxis().getAxisTick().getAxisTickLabels().getBounds(g.getRenderContext()).getWidth() + chart.getStyler()
           .getAxisTickPadding();
-      double yOffset = chart.getYAxis().getBounds().getY();
+      double yOffset = chart.getYAxis().getBounds(g.getRenderContext()).getY();
 
       // bounds
-      bounds = new Rectangle2D.Double(xOffset, yOffset, chart.getStyler().getAxisTickMarkLength(), chart.getYAxis().getBounds().getHeight());
+      bounds = new Rectangle2D.Double(xOffset, yOffset, chart.getStyler().getAxisTickMarkLength(), chart.getYAxis().getBounds(g.getRenderContext()).getHeight());
       // g.setColor(Color.yellow);
       // g.draw(bounds);
 
@@ -70,7 +71,7 @@ public class AxisTickMarks<ST extends AxesChartStyler, S extends Series> impleme
         for (int i = 0; i < chart.getYAxis().getAxisTickCalculator().getTickLabels().size(); i++) {
 
           double tickLocation = chart.getYAxis().getAxisTickCalculator().getTickLocations().get(i);
-          double flippedTickLocation = yOffset + chart.getYAxis().getBounds().getHeight() - tickLocation;
+          double flippedTickLocation = yOffset + chart.getYAxis().getBounds(g.getRenderContext()).getHeight() - tickLocation;
           if (flippedTickLocation > bounds.getY() && flippedTickLocation < bounds.getY() + bounds.getHeight()) {
 
             Shape line = new Line2D.Double(xOffset, flippedTickLocation, xOffset + chart.getStyler().getAxisTickMarkLength(), flippedTickLocation);
@@ -82,7 +83,7 @@ public class AxisTickMarks<ST extends AxesChartStyler, S extends Series> impleme
       // Line
       if (chart.getStyler().isAxisTicksLineVisible()) {
 
-        Shape line = new Line2D.Double(xOffset + chart.getStyler().getAxisTickMarkLength(), yOffset, xOffset + chart.getStyler().getAxisTickMarkLength(), yOffset + chart.getYAxis().getBounds()
+        Shape line = new Line2D.Double(xOffset + chart.getStyler().getAxisTickMarkLength(), yOffset, xOffset + chart.getStyler().getAxisTickMarkLength(), yOffset + chart.getYAxis().getBounds(g.getRenderContext())
             .getHeight());
         g.draw(line);
 
@@ -92,11 +93,11 @@ public class AxisTickMarks<ST extends AxesChartStyler, S extends Series> impleme
     // X-Axis
     else if (direction == Axis.Direction.X && chart.getStyler().isXAxisTicksVisible()) {
 
-      double xOffset = chart.getXAxis().getBounds().getX();
-      double yOffset = chart.getXAxis().getAxisTick().getAxisTickLabels().getBounds().getY() - chart.getStyler().getAxisTickPadding();
+      double xOffset = chart.getXAxis().getBounds(g.getRenderContext()).getX();
+      double yOffset = chart.getXAxis().getAxisTick().getAxisTickLabels().getBounds(g.getRenderContext()).getY() - chart.getStyler().getAxisTickPadding();
 
       // bounds
-      bounds = new Rectangle2D.Double(xOffset, yOffset - chart.getStyler().getAxisTickMarkLength(), chart.getXAxis().getBounds().getWidth(), chart.getStyler().getAxisTickMarkLength());
+      bounds = new Rectangle2D.Double(xOffset, yOffset - chart.getStyler().getAxisTickMarkLength(), chart.getXAxis().getBounds(g.getRenderContext()).getWidth(), chart.getStyler().getAxisTickMarkLength());
       // g.setColor(Color.yellow);
       // g.draw(bounds);
 
@@ -120,7 +121,7 @@ public class AxisTickMarks<ST extends AxesChartStyler, S extends Series> impleme
       if (chart.getStyler().isAxisTicksLineVisible()) {
 
         g.setStroke(chart.getStyler().getAxisTickMarksStroke());
-        g.drawLine((int) xOffset, (int) (yOffset - chart.getStyler().getAxisTickMarkLength()), (int) (xOffset + chart.getXAxis().getBounds().getWidth()), (int) (yOffset - chart.getStyler()
+        g.drawLine((int) xOffset, (int) (yOffset - chart.getStyler().getAxisTickMarkLength()), (int) (xOffset + chart.getXAxis().getBounds(g.getRenderContext()).getWidth()), (int) (yOffset - chart.getStyler()
             .getAxisTickMarkLength()));
       }
 
@@ -132,7 +133,7 @@ public class AxisTickMarks<ST extends AxesChartStyler, S extends Series> impleme
   }
 
   @Override
-  public Rectangle2D getBounds() {
+  public Rectangle2D getBounds(RenderContext rc) {
 
     return bounds;
   }

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxisTitle.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxisTitle.java
@@ -16,17 +16,17 @@
  */
 package org.knowm.xchart.internal.chartpart;
 
-import java.awt.Graphics2D;
-import java.awt.Shape;
-import java.awt.font.FontRenderContext;
-import java.awt.font.TextLayout;
-import java.awt.geom.AffineTransform;
-import java.awt.geom.Rectangle2D;
-
+import org.knowm.xchart.font.TextLayout;
+import org.knowm.xchart.graphics.Graphics;
+import org.knowm.xchart.graphics.RenderContext;
 import org.knowm.xchart.internal.Series;
 import org.knowm.xchart.internal.Series_AxesChart;
 import org.knowm.xchart.internal.chartpart.Axis.Direction;
 import org.knowm.xchart.style.AxesChartStyler;
+
+import java.awt.Shape;
+import java.awt.geom.AffineTransform;
+import java.awt.geom.Rectangle2D;
 
 /**
  * AxisTitle
@@ -50,7 +50,7 @@ public class AxisTitle<ST extends AxesChartStyler, S extends Series> implements 
   }
 
   @Override
-  public void paint(Graphics2D g) {
+  public void paint(Graphics g) {
 
     bounds = new Rectangle2D.Double();
 
@@ -61,14 +61,13 @@ public class AxisTitle<ST extends AxesChartStyler, S extends Series> implements 
 
       if (chart.getyYAxisTitle() != null && !chart.getyYAxisTitle().trim().equalsIgnoreCase("") && chart.getStyler().isYAxisTitleVisible()) {
 
-        FontRenderContext frc = g.getFontRenderContext();
-        TextLayout nonRotatedTextLayout = new TextLayout(chart.getyYAxisTitle(), chart.getStyler().getAxisTitleFont(), frc);
+        TextLayout nonRotatedTextLayout = g.getTextLayout(chart.getyYAxisTitle(), chart.getStyler().getAxisTitleFont());
         Rectangle2D nonRotatedRectangle = nonRotatedTextLayout.getBounds();
 
         // ///////////////////////////////////////////////
 
-        int xOffset = (int) (chart.getYAxis().getBounds().getX() + nonRotatedRectangle.getHeight());
-        int yOffset = (int) ((chart.getYAxis().getBounds().getHeight() + nonRotatedRectangle.getWidth()) / 2.0 + chart.getYAxis().getBounds().getY());
+        int xOffset = (int) (chart.getYAxis().getBounds(g.getRenderContext()).getX() + nonRotatedRectangle.getHeight());
+        int yOffset = (int) ((chart.getYAxis().getBounds(g.getRenderContext()).getHeight() + nonRotatedRectangle.getWidth()) / 2.0 + chart.getYAxis().getBounds(g.getRenderContext()).getY());
 
         AffineTransform rot = AffineTransform.getRotateInstance(-1 * Math.PI / 2, 0, 0);
         Shape shape = nonRotatedTextLayout.getOutline(rot);
@@ -91,7 +90,7 @@ public class AxisTitle<ST extends AxesChartStyler, S extends Series> implements 
         // g.draw(bounds);
       }
       else {
-        bounds = new Rectangle2D.Double(chart.getYAxis().getBounds().getX(), chart.getYAxis().getBounds().getY(), 0, chart.getYAxis().getBounds().getHeight());
+        bounds = new Rectangle2D.Double(chart.getYAxis().getBounds(g.getRenderContext()).getX(), chart.getYAxis().getBounds(g.getRenderContext()).getY(), 0, chart.getYAxis().getBounds(g.getRenderContext()).getHeight());
       }
 
     }
@@ -99,13 +98,12 @@ public class AxisTitle<ST extends AxesChartStyler, S extends Series> implements 
 
       if (chart.getXAxisTitle() != null && !chart.getXAxisTitle().trim().equalsIgnoreCase("") && chart.getStyler().isXAxisTitleVisible()) {
 
-        FontRenderContext frc = g.getFontRenderContext();
-        TextLayout textLayout = new TextLayout(chart.getXAxisTitle(), chart.getStyler().getAxisTitleFont(), frc);
+        TextLayout textLayout = g.getTextLayout(chart.getXAxisTitle(), chart.getStyler().getAxisTitleFont());
         Rectangle2D rectangle = textLayout.getBounds();
         // System.out.println(rectangle);
 
-        double xOffset = chart.getXAxis().getBounds().getX() + (chart.getXAxis().getBounds().getWidth() - rectangle.getWidth()) / 2.0;
-        double yOffset = chart.getXAxis().getBounds().getY() + chart.getXAxis().getBounds().getHeight() - rectangle.getHeight();
+        double xOffset = chart.getXAxis().getBounds(g.getRenderContext()).getX() + (chart.getXAxis().getBounds(g.getRenderContext()).getWidth() - rectangle.getWidth()) / 2.0;
+        double yOffset = chart.getXAxis().getBounds(g.getRenderContext()).getY() + chart.getXAxis().getBounds(g.getRenderContext()).getHeight() - rectangle.getHeight();
 
         // textLayout.draw(g, (float) xOffset, (float) (yOffset - rectangle.getY()));
         Shape shape = textLayout.getOutline(null);
@@ -122,7 +120,7 @@ public class AxisTitle<ST extends AxesChartStyler, S extends Series> implements 
 
       }
       else {
-        bounds = new Rectangle2D.Double(chart.getXAxis().getBounds().getX(), chart.getXAxis().getBounds().getY() + chart.getXAxis().getBounds().getHeight(), chart.getXAxis().getBounds().getWidth(),
+        bounds = new Rectangle2D.Double(chart.getXAxis().getBounds(g.getRenderContext()).getX(), chart.getXAxis().getBounds(g.getRenderContext()).getY() + chart.getXAxis().getBounds(g.getRenderContext()).getHeight(), chart.getXAxis().getBounds(g.getRenderContext()).getWidth(),
             0);
         // g.setColor(Color.blue);
         // g.draw(bounds);
@@ -132,7 +130,7 @@ public class AxisTitle<ST extends AxesChartStyler, S extends Series> implements 
   }
 
   @Override
-  public Rectangle2D getBounds() {
+  public Rectangle2D getBounds(RenderContext rc) {
 
     return bounds;
   }

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Chart.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Chart.java
@@ -16,15 +16,14 @@
  */
 package org.knowm.xchart.internal.chartpart;
 
-import java.awt.Graphics2D;
-import java.awt.RenderingHints;
+import org.knowm.xchart.graphics.Graphics;
+import org.knowm.xchart.internal.Series;
+import org.knowm.xchart.style.Styler;
+
 import java.awt.Shape;
 import java.awt.geom.Rectangle2D;
 import java.util.LinkedHashMap;
 import java.util.Map;
-
-import org.knowm.xchart.internal.Series;
-import org.knowm.xchart.style.Styler;
 
 /**
  * An XChart Chart
@@ -33,7 +32,7 @@ import org.knowm.xchart.style.Styler;
  */
 public abstract class Chart<ST extends Styler, S extends Series> {
 
-  public abstract void paint(Graphics2D g, int width, int height);
+  public abstract void paint(Graphics g, int width, int height);
 
   protected ST styler;
 
@@ -68,10 +67,9 @@ public abstract class Chart<ST extends Styler, S extends Series> {
     this.chartTitle = new ChartTitle(this);
   }
 
-  public void paintBackground(Graphics2D g) {
+  public void paintBackground(Graphics g) {
 
     // paint chart main background
-    g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON); // global rendering hint
     g.setColor(styler.getChartBackgroundColor());
     Shape rect = new Rectangle2D.Double(0, 0, getWidth(), getHeight());
     g.fill(rect);

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/ChartPart.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/ChartPart.java
@@ -16,8 +16,10 @@
  */
 package org.knowm.xchart.internal.chartpart;
 
+import org.knowm.xchart.graphics.Graphics;
+import org.knowm.xchart.graphics.RenderContext;
+
 import java.awt.BasicStroke;
-import java.awt.Graphics2D;
 import java.awt.geom.Rectangle2D;
 
 /**
@@ -29,8 +31,8 @@ public interface ChartPart {
 
   public static BasicStroke SOLID_STROKE = new BasicStroke(1, BasicStroke.CAP_BUTT, BasicStroke.JOIN_BEVEL, 10.0f, new float[] { 3.0f, 0.0f }, 0.0f);
 
-  public Rectangle2D getBounds();
+  public Rectangle2D getBounds(RenderContext rc);
 
-  public void paint(final Graphics2D g);
+  public void paint(final Graphics g);
 
 }

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/ChartTitle.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/ChartTitle.java
@@ -16,11 +16,12 @@
  */
 package org.knowm.xchart.internal.chartpart;
 
+import org.knowm.xchart.font.TextLayout;
+import org.knowm.xchart.graphics.Graphics;
+import org.knowm.xchart.graphics.RenderContext;
+
 import java.awt.BasicStroke;
-import java.awt.Graphics2D;
 import java.awt.Shape;
-import java.awt.font.FontRenderContext;
-import java.awt.font.TextLayout;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.Rectangle2D;
 
@@ -43,7 +44,7 @@ public class ChartTitle implements ChartPart {
   }
 
   @Override
-  public void paint(Graphics2D g) {
+  public void paint(Graphics g) {
 
     g.setFont(chart.getStyler().getChartTitleFont());
 
@@ -52,18 +53,17 @@ public class ChartTitle implements ChartPart {
     }
 
     // create rectangle first for sizing
-    FontRenderContext frc = g.getFontRenderContext();
-    TextLayout textLayout = new TextLayout(chart.getTitle(), chart.getStyler().getChartTitleFont(), frc);
+    TextLayout textLayout = g.getTextLayout(chart.getTitle(), chart.getStyler().getChartTitleFont());
     Rectangle2D textBounds = textLayout.getBounds();
 
-    double xOffset = chart.getPlot().getBounds().getX(); // of plot left edge
+    double xOffset = chart.getPlot().getBounds(g.getRenderContext()).getX(); // of plot left edge
     double yOffset = chart.getStyler().getChartPadding();
 
     // title box
     if (chart.getStyler().isChartTitleBoxVisible()) {
 
       // paint the chart title box
-      double chartTitleBoxWidth = chart.getPlot().getBounds().getWidth();
+      double chartTitleBoxWidth = chart.getPlot().getBounds(g.getRenderContext()).getWidth();
       double chartTitleBoxHeight = textBounds.getHeight() + 2 * chart.getStyler().getChartTitlePadding();
 
       g.setStroke(new BasicStroke(1, BasicStroke.CAP_BUTT, BasicStroke.JOIN_BEVEL));
@@ -75,7 +75,7 @@ public class ChartTitle implements ChartPart {
     }
 
     // paint title
-    xOffset = chart.getPlot().getBounds().getX() + (chart.getPlot().getBounds().getWidth() - textBounds.getWidth()) / 2.0;
+    xOffset = chart.getPlot().getBounds(g.getRenderContext()).getX() + (chart.getPlot().getBounds(g.getRenderContext()).getWidth() - textBounds.getWidth()) / 2.0;
     yOffset = chart.getStyler().getChartPadding() + textBounds.getHeight() + chart.getStyler().getChartTitlePadding();
 
     g.setColor(chart.getStyler().getChartFontColor());
@@ -100,11 +100,11 @@ public class ChartTitle implements ChartPart {
    *
    * @return
    */
-  private Rectangle2D getBoundsHint() {
+  private Rectangle2D getBoundsHint(RenderContext rc) {
 
     if (chart.getStyler().isChartTitleVisible() && chart.getTitle().length() > 0) {
 
-      TextLayout textLayout = new TextLayout(chart.getTitle(), chart.getStyler().getChartTitleFont(), new FontRenderContext(null, true, false));
+      TextLayout textLayout = rc.getTextLayout(chart.getTitle(), chart.getStyler().getChartTitleFont());
       Rectangle2D rectangle = textLayout.getBounds();
       double width = 2 * chart.getStyler().getChartTitlePadding() + rectangle.getWidth();
       double height = 2 * chart.getStyler().getChartTitlePadding() + rectangle.getHeight();
@@ -117,10 +117,10 @@ public class ChartTitle implements ChartPart {
   }
 
   @Override
-  public Rectangle2D getBounds() {
+  public Rectangle2D getBounds(final RenderContext rc) {
 
     if (bounds == null) { // was not drawn fully yet, just need the height hint. The Plot object will be asking for it.
-      bounds = getBoundsHint();
+      bounds = getBoundsHint(rc);
     }
     return bounds;
   }

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Legend_Bubble.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Legend_Bubble.java
@@ -16,17 +16,18 @@
  */
 package org.knowm.xchart.internal.chartpart;
 
-import java.awt.Graphics2D;
-import java.awt.Shape;
-import java.awt.geom.Ellipse2D;
-import java.awt.geom.Rectangle2D;
-import java.util.Map;
-
 import org.knowm.xchart.XYSeries;
+import org.knowm.xchart.graphics.Graphics;
+import org.knowm.xchart.graphics.RenderContext;
 import org.knowm.xchart.internal.Series;
 import org.knowm.xchart.internal.Series_Bubble;
 import org.knowm.xchart.internal.chartpart.RenderableSeries.LegendRenderType;
 import org.knowm.xchart.style.AxesChartStyler;
+
+import java.awt.Shape;
+import java.awt.geom.Ellipse2D;
+import java.awt.geom.Rectangle2D;
+import java.util.Map;
 
 /**
  * @author timmolter
@@ -47,7 +48,7 @@ public class Legend_Bubble<ST extends AxesChartStyler, S extends Series> extends
   }
 
   @Override
-  public void doPaint(Graphics2D g) {
+  public void doPaint(Graphics g) {
 
     // Draw legend content inside legend box
     double startx = xOffset + chart.getStyler().getLegendPadding();
@@ -60,7 +61,7 @@ public class Legend_Bubble<ST extends AxesChartStyler, S extends Series> extends
         continue;
       }
 
-      Map<String, Rectangle2D> seriesTextBounds = getSeriesTextBounds(series);
+      Map<String, Rectangle2D> seriesTextBounds = getSeriesTextBounds(g.getRenderContext(), series);
       float legendEntryHeight = getLegendEntryHeight(seriesTextBounds, BOX_SIZE);
 
       // paint little circle
@@ -81,10 +82,10 @@ public class Legend_Bubble<ST extends AxesChartStyler, S extends Series> extends
   }
 
   @Override
-  public Rectangle2D getBounds() {
+  public Rectangle2D getBounds(RenderContext rc) {
 
     if (bounds == null) { // was not drawn fully yet, just need the height hint. The Axis object may be asking for it.
-      bounds = getBoundsHint();
+      bounds = getBoundsHint(rc);
     }
     return bounds;
   }

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Legend_Marker.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Legend_Marker.java
@@ -16,18 +16,19 @@
  */
 package org.knowm.xchart.internal.chartpart;
 
-import java.awt.Graphics2D;
-import java.awt.Shape;
-import java.awt.geom.Line2D;
-import java.awt.geom.Rectangle2D;
-import java.util.Map;
-
 import org.knowm.xchart.XYSeries;
+import org.knowm.xchart.graphics.Graphics;
+import org.knowm.xchart.graphics.RenderContext;
 import org.knowm.xchart.internal.Series;
 import org.knowm.xchart.internal.Series_Markers;
 import org.knowm.xchart.internal.chartpart.RenderableSeries.LegendRenderType;
 import org.knowm.xchart.style.AxesChartStyler;
 import org.knowm.xchart.style.lines.SeriesLines;
+
+import java.awt.Shape;
+import java.awt.geom.Line2D;
+import java.awt.geom.Rectangle2D;
+import java.util.Map;
 
 /**
  * @author timmolter
@@ -48,7 +49,7 @@ public class Legend_Marker<ST extends AxesChartStyler, S extends Series> extends
   }
 
   @Override
-  public void doPaint(Graphics2D g) {
+  public void doPaint(Graphics g) {
 
     // Draw legend content inside legend box
     double startx = xOffset + chart.getStyler().getLegendPadding();
@@ -61,7 +62,7 @@ public class Legend_Marker<ST extends AxesChartStyler, S extends Series> extends
         continue;
       }
 
-      Map<String, Rectangle2D> seriesTextBounds = getSeriesTextBounds(series);
+      Map<String, Rectangle2D> seriesTextBounds = getSeriesTextBounds(g.getRenderContext(), series);
       float legendEntryHeight = getLegendEntryHeight(seriesTextBounds, (series.getLegendRenderType() == LegendRenderType.Box ? BOX_SIZE : stylerAxesChart.getMarkerSize()));
 
       // paint line and marker
@@ -109,10 +110,10 @@ public class Legend_Marker<ST extends AxesChartStyler, S extends Series> extends
   }
 
   @Override
-  public Rectangle2D getBounds() {
+  public Rectangle2D getBounds(RenderContext rc) {
 
     if (bounds == null) { // was not drawn fully yet, just need the height hint. The Axis object may be asking for it.
-      bounds = getBoundsHint();
+      bounds = getBoundsHint(rc);
     }
     return bounds;
   }

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Legend_Pie.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Legend_Pie.java
@@ -16,15 +16,16 @@
  */
 package org.knowm.xchart.internal.chartpart;
 
-import java.awt.Graphics2D;
-import java.awt.Shape;
-import java.awt.geom.Rectangle2D;
-import java.util.Map;
-
 import org.knowm.xchart.PieSeries;
+import org.knowm.xchart.graphics.Graphics;
+import org.knowm.xchart.graphics.RenderContext;
 import org.knowm.xchart.internal.Series;
 import org.knowm.xchart.style.AxesChartStyler;
 import org.knowm.xchart.style.PieStyler;
+
+import java.awt.Shape;
+import java.awt.geom.Rectangle2D;
+import java.util.Map;
 
 /**
  * @author timmolter
@@ -45,7 +46,7 @@ public class Legend_Pie<ST extends AxesChartStyler, S extends Series> extends Le
   }
 
   @Override
-  public void doPaint(Graphics2D g) {
+  public void doPaint(Graphics g) {
 
     // Draw legend content inside legend box
     double startx = xOffset + chart.getStyler().getLegendPadding();
@@ -58,7 +59,7 @@ public class Legend_Pie<ST extends AxesChartStyler, S extends Series> extends Le
         continue;
       }
 
-      Map<String, Rectangle2D> seriesTextBounds = getSeriesTextBounds(series);
+      Map<String, Rectangle2D> seriesTextBounds = getSeriesTextBounds(g.getRenderContext(), series);
       float legendEntryHeight = getLegendEntryHeight(seriesTextBounds, BOX_SIZE);
 
       // paint little box
@@ -76,10 +77,10 @@ public class Legend_Pie<ST extends AxesChartStyler, S extends Series> extends Le
   }
 
   @Override
-  public Rectangle2D getBounds() {
+  public Rectangle2D getBounds(RenderContext rc) {
 
     if (bounds == null) { // was not drawn fully yet, just need the height hint. The Axis object may be asking for it.
-      bounds = getBoundsHint();
+      bounds = getBoundsHint(rc);
     }
     return bounds;
   }

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_.java
@@ -16,14 +16,15 @@
  */
 package org.knowm.xchart.internal.chartpart;
 
+import org.knowm.xchart.graphics.Graphics;
+import org.knowm.xchart.graphics.RenderContext;
+import org.knowm.xchart.internal.Series;
+import org.knowm.xchart.style.AxesChartStyler;
+
 import java.awt.BasicStroke;
-import java.awt.Graphics2D;
 import java.awt.Stroke;
 import java.awt.geom.Path2D;
 import java.awt.geom.Rectangle2D;
-
-import org.knowm.xchart.internal.Series;
-import org.knowm.xchart.style.AxesChartStyler;
 
 /**
  * @author timmolter
@@ -34,7 +35,7 @@ public abstract class PlotContent_<ST extends AxesChartStyler, S extends Series>
 
   protected final Stroke errorBarStroke = new BasicStroke(1.0f, BasicStroke.CAP_BUTT, BasicStroke.JOIN_BEVEL);
 
-  public abstract void doPaint(Graphics2D g);
+  public abstract void doPaint(Graphics g);
 
   /**
    * Constructor
@@ -47,9 +48,9 @@ public abstract class PlotContent_<ST extends AxesChartStyler, S extends Series>
   }
 
   @Override
-  public void paint(Graphics2D g) {
+  public void paint(Graphics g) {
 
-    Rectangle2D bounds = getBounds();
+    Rectangle2D bounds = getBounds(g.getRenderContext());
     // g.setStroke(new BasicStroke(1, BasicStroke.CAP_BUTT, BasicStroke.JOIN_BEVEL));
     // g.setColor(Color.red);
     // g.draw(bounds);
@@ -69,18 +70,18 @@ public abstract class PlotContent_<ST extends AxesChartStyler, S extends Series>
   }
 
   @Override
-  public Rectangle2D getBounds() {
+  public Rectangle2D getBounds(RenderContext rc) {
 
-    return chart.getPlot().getBounds();
+    return chart.getPlot().getBounds(rc);
   }
 
   /**
    * Closes a path for area charts if one is available.
    */
-  void closePath(Graphics2D g, Path2D.Double path, double previousX, Rectangle2D bounds, double yTopMargin) {
+  void closePath(Graphics g, Path2D.Double path, double previousX, Rectangle2D bounds, double yTopMargin) {
 
     if (path != null) {
-      double yBottomOfArea = getBounds().getY() + getBounds().getHeight() - yTopMargin;
+      double yBottomOfArea = getBounds(g.getRenderContext()).getY() + getBounds(g.getRenderContext()).getHeight() - yTopMargin;
       path.lineTo(previousX, yBottomOfArea);
       path.closePath();
       g.fill(path);

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Bubble.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Bubble.java
@@ -16,20 +16,20 @@
  */
 package org.knowm.xchart.internal.chartpart;
 
-import java.awt.Graphics2D;
+import org.knowm.xchart.BubbleSeries;
+import org.knowm.xchart.graphics.Graphics;
+import org.knowm.xchart.internal.Series;
+import org.knowm.xchart.internal.Utils;
+import org.knowm.xchart.internal.chartpart.Axis.AxisDataType;
+import org.knowm.xchart.style.AxesChartStyler;
+import org.knowm.xchart.style.BubbleStyler;
+
 import java.awt.Shape;
 import java.awt.geom.Ellipse2D;
 import java.util.Collection;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.Map;
-
-import org.knowm.xchart.BubbleSeries;
-import org.knowm.xchart.internal.Series;
-import org.knowm.xchart.internal.Utils;
-import org.knowm.xchart.internal.chartpart.Axis.AxisDataType;
-import org.knowm.xchart.style.AxesChartStyler;
-import org.knowm.xchart.style.BubbleStyler;
 
 /**
  * @author timmolter
@@ -50,15 +50,15 @@ public class PlotContent_Bubble<ST extends AxesChartStyler, S extends Series> ex
   }
 
   @Override
-  public void doPaint(Graphics2D g) {
+  public void doPaint(Graphics g) {
 
     // X-Axis
-    double xTickSpace = stylerBubble.getPlotContentSize() * getBounds().getWidth();
-    double xLeftMargin = Utils.getTickStartOffset((int) getBounds().getWidth(), xTickSpace);
+    double xTickSpace = stylerBubble.getPlotContentSize() * getBounds(g.getRenderContext()).getWidth();
+    double xLeftMargin = Utils.getTickStartOffset((int) getBounds(g.getRenderContext()).getWidth(), xTickSpace);
 
     // Y-Axis
-    double yTickSpace = stylerBubble.getPlotContentSize() * getBounds().getHeight();
-    double yTopMargin = Utils.getTickStartOffset((int) getBounds().getHeight(), yTickSpace);
+    double yTickSpace = stylerBubble.getPlotContentSize() * getBounds(g.getRenderContext()).getHeight();
+    double yTopMargin = Utils.getTickStartOffset((int) getBounds(g.getRenderContext()).getHeight(), yTickSpace);
 
     double xMin = chart.getXAxis().getMin();
     double xMax = chart.getXAxis().getMax();
@@ -130,20 +130,20 @@ public class PlotContent_Bubble<ST extends AxesChartStyler, S extends Series> ex
         // System.out.println(y);
 
         double xTransform = xLeftMargin + ((x - xMin) / (xMax - xMin) * xTickSpace);
-        double yTransform = getBounds().getHeight() - (yTopMargin + (y - yMin) / (yMax - yMin) * yTickSpace);
+        double yTransform = getBounds(g.getRenderContext()).getHeight() - (yTopMargin + (y - yMin) / (yMax - yMin) * yTickSpace);
 
         // a check if all x data are the exact same values
         if (Math.abs(xMax - xMin) / 5 == 0.0) {
-          xTransform = getBounds().getWidth() / 2.0;
+          xTransform = getBounds(g.getRenderContext()).getWidth() / 2.0;
         }
 
         // a check if all y data are the exact same values
         if (Math.abs(yMax - yMin) / 5 == 0.0) {
-          yTransform = getBounds().getHeight() / 2.0;
+          yTransform = getBounds(g.getRenderContext()).getHeight() / 2.0;
         }
 
-        double xOffset = getBounds().getX() + xTransform;
-        double yOffset = getBounds().getY() + yTransform;
+        double xOffset = getBounds(g.getRenderContext()).getX() + xTransform;
+        double yOffset = getBounds(g.getRenderContext()).getY() + yTransform;
         // System.out.println(xTransform);
         // System.out.println(xOffset);
         // System.out.println(yTransform);

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Category_Bar.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Category_Bar.java
@@ -16,10 +16,17 @@
  */
 package org.knowm.xchart.internal.chartpart;
 
-import java.awt.Graphics2D;
+import org.knowm.xchart.CategorySeries;
+import org.knowm.xchart.CategorySeries.CategorySeriesRenderStyle;
+import org.knowm.xchart.font.TextLayout;
+import org.knowm.xchart.graphics.Graphics;
+import org.knowm.xchart.internal.Series;
+import org.knowm.xchart.internal.Utils;
+import org.knowm.xchart.style.CategoryStyler;
+import org.knowm.xchart.style.Styler;
+import org.knowm.xchart.style.lines.SeriesLines;
+
 import java.awt.Shape;
-import java.awt.font.FontRenderContext;
-import java.awt.font.TextLayout;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.Line2D;
 import java.awt.geom.Path2D;
@@ -28,14 +35,6 @@ import java.text.DecimalFormat;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.Map;
-
-import org.knowm.xchart.CategorySeries;
-import org.knowm.xchart.CategorySeries.CategorySeriesRenderStyle;
-import org.knowm.xchart.internal.Series;
-import org.knowm.xchart.internal.Utils;
-import org.knowm.xchart.style.CategoryStyler;
-import org.knowm.xchart.style.Styler;
-import org.knowm.xchart.style.lines.SeriesLines;
 
 /**
  * @author timmolter
@@ -56,12 +55,12 @@ public class PlotContent_Category_Bar<ST extends Styler, S extends Series> exten
   }
 
   @Override
-  public void doPaint(Graphics2D g) {
+  public void doPaint(Graphics g) {
 
     // X-Axis
-    double xTickSpace = stylerCategory.getPlotContentSize() * getBounds().getWidth();
+    double xTickSpace = stylerCategory.getPlotContentSize() * getBounds(g.getRenderContext()).getWidth();
     // System.out.println("xTickSpace: " + xTickSpace);
-    double xLeftMargin = Utils.getTickStartOffset(getBounds().getWidth(), xTickSpace);
+    double xLeftMargin = Utils.getTickStartOffset(getBounds(g.getRenderContext()).getWidth(), xTickSpace);
     // System.out.println("xLeftMargin: " + xLeftMargin);
     Map<String, CategorySeries> seriesMap = chart.getSeriesMap();
     int numCategories = seriesMap.values().iterator().next().getXData().size();
@@ -87,9 +86,9 @@ public class PlotContent_Category_Bar<ST extends Styler, S extends Series> exten
     // System.out.println(yMax);
     // System.out.println("chartForm: " + chartForm);
 
-    double yTickSpace = stylerCategory.getPlotContentSize() * getBounds().getHeight();
+    double yTickSpace = stylerCategory.getPlotContentSize() * getBounds(g.getRenderContext()).getHeight();
 
-    double yTopMargin = Utils.getTickStartOffset(getBounds().getHeight(), yTickSpace);
+    double yTopMargin = Utils.getTickStartOffset(getBounds(g.getRenderContext()).getHeight(), yTickSpace);
 
     // plot series
     int seriesCounter = 0;
@@ -178,13 +177,13 @@ public class PlotContent_Category_Bar<ST extends Styler, S extends Series> exten
           break;
         }
 
-        double yTransform = getBounds().getHeight() - (yTopMargin + (yTop - yMin) / (yMax - yMin) * yTickSpace);
+        double yTransform = getBounds(g.getRenderContext()).getHeight() - (yTopMargin + (yTop - yMin) / (yMax - yMin) * yTickSpace);
         // double yTransform = bounds.getHeight() - (yTopMargin + (y - yMin) / (yMax - yMin) * yTickSpace);
 
-        double yOffset = getBounds().getY() + yTransform;
+        double yOffset = getBounds(g.getRenderContext()).getY() + yTransform;
 
-        double zeroTransform = getBounds().getHeight() - (yTopMargin + (yBottom - yMin) / (yMax - yMin) * yTickSpace);
-        double zeroOffset = getBounds().getY() + zeroTransform;
+        double zeroTransform = getBounds(g.getRenderContext()).getHeight() - (yTopMargin + (yBottom - yMin) / (yMax - yMin) * yTickSpace);
+        double zeroOffset = getBounds(g.getRenderContext()).getY() + zeroTransform;
         double xOffset;
         double barWidth;
 
@@ -192,13 +191,13 @@ public class PlotContent_Category_Bar<ST extends Styler, S extends Series> exten
           double barWidthPercentage = stylerCategory.getAvailableSpaceFill();
           barWidth = gridStep * barWidthPercentage;
           double barMargin = gridStep * (1 - barWidthPercentage) / 2;
-          xOffset = getBounds().getX() + xLeftMargin + gridStep * categoryCounter++ + barMargin;
+          xOffset = getBounds(g.getRenderContext()).getX() + xLeftMargin + gridStep * categoryCounter++ + barMargin;
         }
         else {
           double barWidthPercentage = stylerCategory.getAvailableSpaceFill();
           barWidth = gridStep / chart.getSeriesMap().size() * barWidthPercentage;
           double barMargin = gridStep * (1 - barWidthPercentage) / 2;
-          xOffset = getBounds().getX() + xLeftMargin + gridStep * categoryCounter++ + seriesCounter * barWidth + barMargin;
+          xOffset = getBounds(g.getRenderContext()).getX() + xLeftMargin + gridStep * categoryCounter++ + seriesCounter * barWidth + barMargin;
         }
 
         // paint series
@@ -227,7 +226,7 @@ public class PlotContent_Category_Bar<ST extends Styler, S extends Series> exten
             }
             String numberAsString = twoPlaces.format(next);
 
-            TextLayout textLayout = new TextLayout(numberAsString, stylerCategory.getAnnotationsFont(), new FontRenderContext(null, true, false));
+            TextLayout textLayout = g.getTextLayout(numberAsString, stylerCategory.getAnnotationsFont());
             Rectangle2D annotationRectangle = textLayout.getBounds();
 
             double annotationX = xOffset + barWidth / 2 - annotationRectangle.getWidth() / 2;

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Category_Line_Area_Scatter.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Category_Line_Area_Scatter.java
@@ -16,21 +16,21 @@
  */
 package org.knowm.xchart.internal.chartpart;
 
-import java.awt.Graphics2D;
+import org.knowm.xchart.CategorySeries;
+import org.knowm.xchart.CategorySeries.CategorySeriesRenderStyle;
+import org.knowm.xchart.graphics.Graphics;
+import org.knowm.xchart.internal.Series;
+import org.knowm.xchart.internal.Utils;
+import org.knowm.xchart.style.CategoryStyler;
+import org.knowm.xchart.style.Styler;
+import org.knowm.xchart.style.lines.SeriesLines;
+
 import java.awt.Shape;
 import java.awt.geom.Line2D;
 import java.awt.geom.Path2D;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.Map;
-
-import org.knowm.xchart.CategorySeries;
-import org.knowm.xchart.CategorySeries.CategorySeriesRenderStyle;
-import org.knowm.xchart.internal.Series;
-import org.knowm.xchart.internal.Utils;
-import org.knowm.xchart.style.CategoryStyler;
-import org.knowm.xchart.style.Styler;
-import org.knowm.xchart.style.lines.SeriesLines;
 
 /**
  * @author timmolter
@@ -51,7 +51,7 @@ public class PlotContent_Category_Line_Area_Scatter<ST extends Styler, S extends
   }
 
   @Override
-  public void doPaint(Graphics2D g) {
+  public void doPaint(Graphics g) {
 
     // logarithmic
     // if (stylerCategory.isYAxisLogarithmic()) {
@@ -59,12 +59,12 @@ public class PlotContent_Category_Line_Area_Scatter<ST extends Styler, S extends
     // }
 
     // X-Axis
-    double xTickSpace = stylerCategory.getPlotContentSize() * getBounds().getWidth();
-    double xLeftMargin = Utils.getTickStartOffset((int) getBounds().getWidth(), xTickSpace);
+    double xTickSpace = stylerCategory.getPlotContentSize() * getBounds(g.getRenderContext()).getWidth();
+    double xLeftMargin = Utils.getTickStartOffset((int) getBounds(g.getRenderContext()).getWidth(), xTickSpace);
 
     // Y-Axis
-    double yTickSpace = stylerCategory.getPlotContentSize() * getBounds().getHeight();
-    double yTopMargin = Utils.getTickStartOffset((int) getBounds().getHeight(), yTickSpace);
+    double yTickSpace = stylerCategory.getPlotContentSize() * getBounds(g.getRenderContext()).getHeight();
+    double yTopMargin = Utils.getTickStartOffset((int) getBounds(g.getRenderContext()).getHeight(), yTickSpace);
 
     double xMin = chart.getAxisPair().getXAxis().getMin();
     double xMax = chart.getAxisPair().getXAxis().getMax();
@@ -111,7 +111,7 @@ public class PlotContent_Category_Line_Area_Scatter<ST extends Styler, S extends
         if (next == null) {
 
           // for area charts
-          closePath(g, path, previousX, getBounds(), yTopMargin);
+          closePath(g, path, previousX, getBounds(g.getRenderContext()), yTopMargin);
           path = null;
 
           previousX = -Double.MAX_VALUE;
@@ -132,15 +132,15 @@ public class PlotContent_Category_Line_Area_Scatter<ST extends Styler, S extends
         }
         // System.out.println(y);
 
-        double yTransform = getBounds().getHeight() - (yTopMargin + (y - yMin) / (yMax - yMin) * yTickSpace);
+        double yTransform = getBounds(g.getRenderContext()).getHeight() - (yTopMargin + (y - yMin) / (yMax - yMin) * yTickSpace);
 
         // a check if all y data are the exact same values
         if (Math.abs(yMax - yMin) / 5 == 0.0) {
-          yTransform = getBounds().getHeight() / 2.0;
+          yTransform = getBounds(g.getRenderContext()).getHeight() / 2.0;
         }
 
-        double xOffset = getBounds().getX() + xLeftMargin + categoryCounter++ * gridStep + gridStep / 2;
-        double yOffset = getBounds().getY() + yTransform;
+        double xOffset = getBounds(g.getRenderContext()).getX() + xLeftMargin + categoryCounter++ * gridStep + gridStep / 2;
+        double yOffset = getBounds(g.getRenderContext()).getY() + yTransform;
         // System.out.println(xOffset);
         // System.out.println(yTransform);
         // System.out.println(yOffset);
@@ -166,7 +166,7 @@ public class PlotContent_Category_Line_Area_Scatter<ST extends Styler, S extends
           if (previousX != -Double.MAX_VALUE && previousY != -Double.MAX_VALUE) {
 
             g.setColor(series.getFillColor());
-            double yBottomOfArea = getBounds().getY() + getBounds().getHeight() - yTopMargin;
+            double yBottomOfArea = getBounds(g.getRenderContext()).getY() + getBounds(g.getRenderContext()).getHeight() - yTopMargin;
 
             if (path == null) {
               path = new Path2D.Double();
@@ -185,7 +185,7 @@ public class PlotContent_Category_Line_Area_Scatter<ST extends Styler, S extends
 
           if (series.getLineStyle() != SeriesLines.NONE) {
 
-            double yBottomOfArea = getBounds().getY() + getBounds().getHeight() - yTopMargin;
+            double yBottomOfArea = getBounds(g.getRenderContext()).getY() + getBounds(g.getRenderContext()).getHeight() - yTopMargin;
 
             g.setColor(series.getLineColor());
             g.setStroke(series.getLineStyle());
@@ -227,8 +227,8 @@ public class PlotContent_Category_Line_Area_Scatter<ST extends Styler, S extends
           else {
             topValue = y + eb;
           }
-          double topEBTransform = getBounds().getHeight() - (yTopMargin + (topValue - yMin) / (yMax - yMin) * yTickSpace);
-          double topEBOffset = getBounds().getY() + topEBTransform;
+          double topEBTransform = getBounds(g.getRenderContext()).getHeight() - (yTopMargin + (topValue - yMin) / (yMax - yMin) * yTickSpace);
+          double topEBOffset = getBounds(g.getRenderContext()).getY() + topEBTransform;
 
           // Bottom value
           double bottomValue = 0.0;
@@ -240,8 +240,8 @@ public class PlotContent_Category_Line_Area_Scatter<ST extends Styler, S extends
           else {
             bottomValue = y - eb;
           }
-          double bottomEBTransform = getBounds().getHeight() - (yTopMargin + (bottomValue - yMin) / (yMax - yMin) * yTickSpace);
-          double bottomEBOffset = getBounds().getY() + bottomEBTransform;
+          double bottomEBTransform = getBounds(g.getRenderContext()).getHeight() - (yTopMargin + (bottomValue - yMin) / (yMax - yMin) * yTickSpace);
+          double bottomEBOffset = getBounds(g.getRenderContext()).getY() + bottomEBTransform;
 
           // Draw it
           Shape line = new Line2D.Double(xOffset, topEBOffset, xOffset, bottomEBOffset);
@@ -254,7 +254,7 @@ public class PlotContent_Category_Line_Area_Scatter<ST extends Styler, S extends
       }
 
       // close any open path for area charts
-      closePath(g, path, previousX, getBounds(), yTopMargin);
+      closePath(g, path, previousX, getBounds(g.getRenderContext()), yTopMargin);
     }
 
   }

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Pie.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Pie.java
@@ -16,11 +16,19 @@
  */
 package org.knowm.xchart.internal.chartpart;
 
+import org.knowm.xchart.PieSeries;
+import org.knowm.xchart.PieSeries.PieSeriesRenderStyle;
+import org.knowm.xchart.font.Java2DTextLayout;
+import org.knowm.xchart.font.TextLayout;
+import org.knowm.xchart.graphics.Graphics;
+import org.knowm.xchart.internal.Series;
+import org.knowm.xchart.style.PieStyler;
+import org.knowm.xchart.style.PieStyler.AnnotationType;
+import org.knowm.xchart.style.Styler;
+
 import java.awt.BasicStroke;
-import java.awt.Graphics2D;
 import java.awt.Shape;
 import java.awt.font.FontRenderContext;
-import java.awt.font.TextLayout;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.Arc2D;
 import java.awt.geom.GeneralPath;
@@ -29,13 +37,6 @@ import java.awt.geom.Point2D;
 import java.awt.geom.Rectangle2D;
 import java.text.DecimalFormat;
 import java.util.Map;
-
-import org.knowm.xchart.PieSeries;
-import org.knowm.xchart.PieSeries.PieSeriesRenderStyle;
-import org.knowm.xchart.internal.Series;
-import org.knowm.xchart.style.PieStyler;
-import org.knowm.xchart.style.PieStyler.AnnotationType;
-import org.knowm.xchart.style.Styler;
 
 /**
  * @author timmolter
@@ -57,20 +58,20 @@ public class PlotContent_Pie<ST extends Styler, S extends Series> extends PlotCo
   }
 
   @Override
-  public void doPaint(Graphics2D g) {
+  public void doPaint(Graphics g) {
 
     // pie getBounds()
     double pieFillPercentage = stylerPie.getPlotContentSize();
 
     double halfBorderPercentage = (1 - pieFillPercentage) / 2.0;
-    double width = stylerPie.isCircular() ? Math.min(getBounds().getWidth(), getBounds().getHeight()) : getBounds().getWidth();
-    double height = stylerPie.isCircular() ? Math.min(getBounds().getWidth(), getBounds().getHeight()) : getBounds().getHeight();
+    double width = stylerPie.isCircular() ? Math.min(getBounds(g.getRenderContext()).getWidth(), getBounds(g.getRenderContext()).getHeight()) : getBounds(g.getRenderContext()).getWidth();
+    double height = stylerPie.isCircular() ? Math.min(getBounds(g.getRenderContext()).getWidth(), getBounds(g.getRenderContext()).getHeight()) : getBounds(g.getRenderContext()).getHeight();
 
     Rectangle2D pieBounds = new Rectangle2D.Double(
 
-        getBounds().getX() + getBounds().getWidth() / 2 - width / 2 + halfBorderPercentage * width,
+        getBounds(g.getRenderContext()).getX() + getBounds(g.getRenderContext()).getWidth() / 2 - width / 2 + halfBorderPercentage * width,
 
-        getBounds().getY() + getBounds().getHeight() / 2 - height / 2 + halfBorderPercentage * height,
+        getBounds(g.getRenderContext()).getY() + getBounds(g.getRenderContext()).getHeight() / 2 - height / 2 + halfBorderPercentage * height,
 
         width * pieFillPercentage,
 
@@ -138,7 +139,7 @@ public class PlotContent_Pie<ST extends Styler, S extends Series> extends PlotCo
           annotation = df.format(percentage) + "%";
         }
 
-        TextLayout textLayout = new TextLayout(annotation, stylerPie.getAnnotationsFont(), new FontRenderContext(null, true, false));
+        TextLayout textLayout = g.getTextLayout(annotation, stylerPie.getAnnotationsFont());
         Rectangle2D annotationRectangle = textLayout.getBounds();
 
         double xCenter = pieBounds.getX() + pieBounds.getWidth() / 2 - annotationRectangle.getWidth() / 2;

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_XY.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_XY.java
@@ -16,7 +16,16 @@
  */
 package org.knowm.xchart.internal.chartpart;
 
-import java.awt.Graphics2D;
+import org.knowm.xchart.XYSeries;
+import org.knowm.xchart.XYSeries.XYSeriesRenderStyle;
+import org.knowm.xchart.graphics.Graphics;
+import org.knowm.xchart.internal.Series;
+import org.knowm.xchart.internal.Utils;
+import org.knowm.xchart.internal.chartpart.Axis.AxisDataType;
+import org.knowm.xchart.style.AxesChartStyler;
+import org.knowm.xchart.style.XYStyler;
+import org.knowm.xchart.style.lines.SeriesLines;
+
 import java.awt.Shape;
 import java.awt.geom.Line2D;
 import java.awt.geom.Path2D;
@@ -24,15 +33,6 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.Map;
-
-import org.knowm.xchart.XYSeries;
-import org.knowm.xchart.XYSeries.XYSeriesRenderStyle;
-import org.knowm.xchart.internal.Series;
-import org.knowm.xchart.internal.Utils;
-import org.knowm.xchart.internal.chartpart.Axis.AxisDataType;
-import org.knowm.xchart.style.AxesChartStyler;
-import org.knowm.xchart.style.XYStyler;
-import org.knowm.xchart.style.lines.SeriesLines;
 
 /**
  * @author timmolter
@@ -53,15 +53,15 @@ public class PlotContent_XY<ST extends AxesChartStyler, S extends Series> extend
   }
 
   @Override
-  public void doPaint(Graphics2D g) {
+  public void doPaint(Graphics g) {
 
     // X-Axis
-    double xTickSpace = stylerXY.getPlotContentSize() * getBounds().getWidth();
-    double xLeftMargin = Utils.getTickStartOffset((int) getBounds().getWidth(), xTickSpace);
+    double xTickSpace = stylerXY.getPlotContentSize() * getBounds(g.getRenderContext()).getWidth();
+    double xLeftMargin = Utils.getTickStartOffset((int) getBounds(g.getRenderContext()).getWidth(), xTickSpace);
 
     // Y-Axis
-    double yTickSpace = stylerXY.getPlotContentSize() * getBounds().getHeight();
-    double yTopMargin = Utils.getTickStartOffset((int) getBounds().getHeight(), yTickSpace);
+    double yTickSpace = stylerXY.getPlotContentSize() * getBounds(g.getRenderContext()).getHeight();
+    double yTopMargin = Utils.getTickStartOffset((int) getBounds(g.getRenderContext()).getHeight(), yTickSpace);
 
     double xMin = chart.getXAxis().getMin();
     double xMax = chart.getXAxis().getMax();
@@ -116,7 +116,7 @@ public class PlotContent_XY<ST extends AxesChartStyler, S extends Series> extend
         if (next == null) {
 
           // for area charts
-          closePath(g, path, previousX, getBounds(), yTopMargin);
+          closePath(g, path, previousX, getBounds(g.getRenderContext()), yTopMargin);
           path = null;
 
           previousX = -Double.MAX_VALUE;
@@ -138,20 +138,20 @@ public class PlotContent_XY<ST extends AxesChartStyler, S extends Series> extend
         // System.out.println(y);
 
         double xTransform = xLeftMargin + ((x - xMin) / (xMax - xMin) * xTickSpace);
-        double yTransform = getBounds().getHeight() - (yTopMargin + (y - yMin) / (yMax - yMin) * yTickSpace);
+        double yTransform = getBounds(g.getRenderContext()).getHeight() - (yTopMargin + (y - yMin) / (yMax - yMin) * yTickSpace);
 
         // a check if all x data are the exact same values
         if (Math.abs(xMax - xMin) / 5 == 0.0) {
-          xTransform = getBounds().getWidth() / 2.0;
+          xTransform = getBounds(g.getRenderContext()).getWidth() / 2.0;
         }
 
         // a check if all y data are the exact same values
         if (Math.abs(yMax - yMin) / 5 == 0.0) {
-          yTransform = getBounds().getHeight() / 2.0;
+          yTransform = getBounds(g.getRenderContext()).getHeight() / 2.0;
         }
 
-        double xOffset = getBounds().getX() + xTransform;
-        double yOffset = getBounds().getY() + yTransform;
+        double xOffset = getBounds(g.getRenderContext()).getX() + xTransform;
+        double yOffset = getBounds(g.getRenderContext()).getY() + yTransform;
         // System.out.println(xTransform);
         // System.out.println(xOffset);
         // System.out.println(yTransform);
@@ -180,7 +180,7 @@ public class PlotContent_XY<ST extends AxesChartStyler, S extends Series> extend
           if (previousX != -Double.MAX_VALUE && previousY != -Double.MAX_VALUE) {
 
             g.setColor(series.getFillColor());
-            double yBottomOfArea = getBounds().getY() + getBounds().getHeight() - yTopMargin;
+            double yBottomOfArea = getBounds(g.getRenderContext()).getY() + getBounds(g.getRenderContext()).getHeight() - yTopMargin;
 
             if (path == null) {
               path = new Path2D.Double();
@@ -226,8 +226,8 @@ public class PlotContent_XY<ST extends AxesChartStyler, S extends Series> extend
           else {
             topValue = y + eb;
           }
-          double topEBTransform = getBounds().getHeight() - (yTopMargin + (topValue - yMin) / (yMax - yMin) * yTickSpace);
-          double topEBOffset = getBounds().getY() + topEBTransform;
+          double topEBTransform = getBounds(g.getRenderContext()).getHeight() - (yTopMargin + (topValue - yMin) / (yMax - yMin) * yTickSpace);
+          double topEBOffset = getBounds(g.getRenderContext()).getY() + topEBTransform;
 
           // Bottom value
           double bottomValue = 0.0;
@@ -239,8 +239,8 @@ public class PlotContent_XY<ST extends AxesChartStyler, S extends Series> extend
           else {
             bottomValue = y - eb;
           }
-          double bottomEBTransform = getBounds().getHeight() - (yTopMargin + (bottomValue - yMin) / (yMax - yMin) * yTickSpace);
-          double bottomEBOffset = getBounds().getY() + bottomEBTransform;
+          double bottomEBTransform = getBounds(g.getRenderContext()).getHeight() - (yTopMargin + (bottomValue - yMin) / (yMax - yMin) * yTickSpace);
+          double bottomEBOffset = getBounds(g.getRenderContext()).getY() + bottomEBTransform;
 
           // Draw it
           Shape line = new Line2D.Double(xOffset, topEBOffset, xOffset, bottomEBOffset);
@@ -253,7 +253,7 @@ public class PlotContent_XY<ST extends AxesChartStyler, S extends Series> extend
       }
 
       // close any open path for area charts
-      closePath(g, path, previousX, getBounds(), yTopMargin);
+      closePath(g, path, previousX, getBounds(g.getRenderContext()), yTopMargin);
     }
 
   }

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotSurface_.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotSurface_.java
@@ -16,10 +16,11 @@
  */
 package org.knowm.xchart.internal.chartpart;
 
-import java.awt.geom.Rectangle2D;
-
+import org.knowm.xchart.graphics.RenderContext;
 import org.knowm.xchart.internal.Series;
 import org.knowm.xchart.style.Styler;
+
+import java.awt.geom.Rectangle2D;
 
 /**
  * @author timmolter
@@ -39,8 +40,8 @@ public abstract class PlotSurface_<ST extends Styler, S extends Series> implemen
   }
 
   @Override
-  public Rectangle2D getBounds() {
+  public Rectangle2D getBounds(RenderContext rc) {
 
-    return chart.getPlot().getBounds();
+    return chart.getPlot().getBounds(rc);
   }
 }

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotSurface_AxesChart.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotSurface_AxesChart.java
@@ -16,16 +16,16 @@
  */
 package org.knowm.xchart.internal.chartpart;
 
-import java.awt.Graphics2D;
+import org.knowm.xchart.XYSeries;
+import org.knowm.xchart.graphics.Graphics;
+import org.knowm.xchart.internal.Series;
+import org.knowm.xchart.style.AxesChartStyler;
+import org.knowm.xchart.style.Styler;
+
 import java.awt.Shape;
 import java.awt.geom.Line2D;
 import java.awt.geom.Rectangle2D;
 import java.util.List;
-
-import org.knowm.xchart.XYSeries;
-import org.knowm.xchart.internal.Series;
-import org.knowm.xchart.style.AxesChartStyler;
-import org.knowm.xchart.style.Styler;
 
 /**
  * Draws the plot background, the plot border and the horizontal and vertical grid lines
@@ -48,9 +48,9 @@ public class PlotSurface_AxesChart<ST extends Styler, S extends Series> extends 
   }
 
   @Override
-  public void paint(Graphics2D g) {
+  public void paint(Graphics g) {
 
-    Rectangle2D bounds = getBounds();
+    Rectangle2D bounds = getBounds(g.getRenderContext());
 
     // paint plot background
     Shape rect = new Rectangle2D.Double(bounds.getX(), bounds.getY(), bounds.getWidth(), bounds.getHeight());

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotSurface_Pie.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotSurface_Pie.java
@@ -16,14 +16,14 @@
  */
 package org.knowm.xchart.internal.chartpart;
 
-import java.awt.Graphics2D;
-import java.awt.Shape;
-import java.awt.geom.Rectangle2D;
-
 import org.knowm.xchart.PieSeries;
+import org.knowm.xchart.graphics.Graphics;
 import org.knowm.xchart.internal.Series;
 import org.knowm.xchart.style.PieStyler;
 import org.knowm.xchart.style.Styler;
+
+import java.awt.Shape;
+import java.awt.geom.Rectangle2D;
 
 /**
  * Draws the plot background and the plot border
@@ -46,9 +46,9 @@ public class PlotSurface_Pie<ST extends Styler, S extends Series> extends PlotSu
   }
 
   @Override
-  public void paint(Graphics2D g) {
+  public void paint(Graphics g) {
 
-    Rectangle2D bounds = getBounds();
+    Rectangle2D bounds = getBounds(g.getRenderContext());
 
     // paint plot background
     Shape rect = new Rectangle2D.Double(bounds.getX(), bounds.getY(), bounds.getWidth(), bounds.getHeight());

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Plot_.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Plot_.java
@@ -16,11 +16,12 @@
  */
 package org.knowm.xchart.internal.chartpart;
 
-import java.awt.Graphics2D;
-import java.awt.geom.Rectangle2D;
-
+import org.knowm.xchart.graphics.Graphics;
+import org.knowm.xchart.graphics.RenderContext;
 import org.knowm.xchart.internal.Series;
 import org.knowm.xchart.style.Styler;
+
+import java.awt.geom.Rectangle2D;
 
 /**
  * @author timmolter
@@ -44,7 +45,7 @@ public class Plot_<ST extends Styler, S extends Series> implements ChartPart {
   }
 
   @Override
-  public void paint(Graphics2D g) {
+  public void paint(Graphics g) {
 
     // g.setColor(Color.red);
     // g.draw(bounds);
@@ -58,7 +59,7 @@ public class Plot_<ST extends Styler, S extends Series> implements ChartPart {
   }
 
   @Override
-  public Rectangle2D getBounds() {
+  public Rectangle2D getBounds(RenderContext rc) {
 
     return bounds;
   }

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Plot_AxesChart.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Plot_AxesChart.java
@@ -16,13 +16,13 @@
  */
 package org.knowm.xchart.internal.chartpart;
 
-import java.awt.Graphics2D;
-import java.awt.geom.Rectangle2D;
-
 import org.knowm.xchart.XYSeries;
+import org.knowm.xchart.graphics.Graphics;
 import org.knowm.xchart.internal.Series;
 import org.knowm.xchart.style.AxesChartStyler;
 import org.knowm.xchart.style.Styler;
+
+import java.awt.geom.Rectangle2D;
 
 /**
  * @author timmolter
@@ -44,16 +44,16 @@ public class Plot_AxesChart<ST extends Styler, S extends Series> extends Plot_ {
   }
 
   @Override
-  public void paint(Graphics2D g) {
+  public void paint(Graphics g) {
 
     // calculate bounds
-    double xOffset = chart.getYAxis().getBounds().getX() + chart.getYAxis().getBounds().getWidth()
+    double xOffset = chart.getYAxis().getBounds(g.getRenderContext()).getX() + chart.getYAxis().getBounds(g.getRenderContext()).getWidth()
 
         + (stylerAxesChart.isYAxisTicksVisible() ? stylerAxesChart.getPlotMargin() : 0);
 
-    double yOffset = chart.getYAxis().getBounds().getY();
-    double width = chart.getXAxis().getBounds().getWidth();
-    double height = chart.getYAxis().getBounds().getHeight();
+    double yOffset = chart.getYAxis().getBounds(g.getRenderContext()).getY();
+    double width = chart.getXAxis().getBounds(g.getRenderContext()).getWidth();
+    double height = chart.getYAxis().getBounds(g.getRenderContext()).getHeight();
     this.bounds = new Rectangle2D.Double(xOffset, yOffset, width, height);
 
     super.paint(g);

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Plot_Category.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Plot_Category.java
@@ -16,10 +16,9 @@
  */
 package org.knowm.xchart.internal.chartpart;
 
-import java.awt.Graphics2D;
-
 import org.knowm.xchart.CategorySeries;
 import org.knowm.xchart.CategorySeries.CategorySeriesRenderStyle;
+import org.knowm.xchart.graphics.Graphics;
 import org.knowm.xchart.internal.Series;
 import org.knowm.xchart.style.AxesChartStyler;
 import org.knowm.xchart.style.CategoryStyler;
@@ -43,7 +42,7 @@ public class Plot_Category<ST extends AxesChartStyler, S extends Series> extends
   }
 
   @Override
-  public void paint(Graphics2D g) {
+  public void paint(Graphics g) {
 
     if (CategorySeriesRenderStyle.Bar.equals(stylerCategory.getDefaultSeriesRenderStyle()) || CategorySeriesRenderStyle.Stick.equals(stylerCategory.getDefaultSeriesRenderStyle())) {
 

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Plot_Pie.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Plot_Pie.java
@@ -16,14 +16,14 @@
  */
 package org.knowm.xchart.internal.chartpart;
 
-import java.awt.Graphics2D;
-import java.awt.geom.Rectangle2D;
-
 import org.knowm.xchart.PieSeries;
+import org.knowm.xchart.graphics.Graphics;
 import org.knowm.xchart.internal.Series;
 import org.knowm.xchart.style.PieStyler;
 import org.knowm.xchart.style.Styler;
 import org.knowm.xchart.style.Styler.LegendPosition;
+
+import java.awt.geom.Rectangle2D;
 
 /**
  * @author timmolter
@@ -43,25 +43,25 @@ public class Plot_Pie<ST extends Styler, S extends Series> extends Plot_ {
   }
 
   @Override
-  public void paint(Graphics2D g) {
+  public void paint(Graphics g) {
 
     // calculate bounds
     double xOffset = chart.getStyler().getChartPadding();
 
     // double yOffset = chart.getChartTitle().getBounds().getHeight() + 2 * chart.getStyler().getChartPadding();
-    double yOffset = chart.getChartTitle().getBounds().getHeight() + chart.getStyler().getChartPadding();
+    double yOffset = chart.getChartTitle().getBounds(g.getRenderContext()).getHeight() + chart.getStyler().getChartPadding();
 
     double width =
 
         chart.getWidth()
 
-            - (chart.getStyler().getLegendPosition() == LegendPosition.OutsideE ? chart.getLegend().getBounds().getWidth() : 0)
+            - (chart.getStyler().getLegendPosition() == LegendPosition.OutsideE ? chart.getLegend().getBounds(g.getRenderContext()).getWidth() : 0)
 
             - 2 * chart.getStyler().getChartPadding()
 
             - (chart.getStyler().getLegendPosition() == LegendPosition.OutsideE && chart.getStyler().isLegendVisible() ? chart.getStyler().getChartPadding() : 0);
 
-    double height = chart.getHeight() - chart.getChartTitle().getBounds().getHeight() - 2 * chart.getStyler().getChartPadding();
+    double height = chart.getHeight() - chart.getChartTitle().getBounds(g.getRenderContext()).getHeight() - 2 * chart.getStyler().getChartPadding();
 
     this.bounds = new Rectangle2D.Double(xOffset, yOffset, width, height);
 

--- a/xchart/src/main/java/org/knowm/xchart/style/AxesChartStyler.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/AxesChartStyler.java
@@ -16,8 +16,9 @@
  */
 package org.knowm.xchart.style;
 
+import org.knowm.xchart.Font;
+
 import java.awt.Color;
-import java.awt.Font;
 import java.awt.Stroke;
 import java.util.Locale;
 import java.util.TimeZone;

--- a/xchart/src/main/java/org/knowm/xchart/style/GGPlot2Theme.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/GGPlot2Theme.java
@@ -16,11 +16,7 @@
  */
 package org.knowm.xchart.style;
 
-import java.awt.BasicStroke;
-import java.awt.Color;
-import java.awt.Font;
-import java.awt.Stroke;
-
+import org.knowm.xchart.Font;
 import org.knowm.xchart.style.PieStyler.AnnotationType;
 import org.knowm.xchart.style.Styler.LegendPosition;
 import org.knowm.xchart.style.colors.ChartColor;
@@ -29,10 +25,14 @@ import org.knowm.xchart.style.lines.GGPlot2SeriesLines;
 import org.knowm.xchart.style.markers.GGPlot2SeriesMarkers;
 import org.knowm.xchart.style.markers.Marker;
 
+import java.awt.BasicStroke;
+import java.awt.Color;
+import java.awt.Stroke;
+
 /**
  * @author timmolter
  */
-public class GGPlot2Theme implements Theme {
+public class GGPlot2Theme extends Theme {
 
   // Chart Style ///////////////////////////////
 

--- a/xchart/src/main/java/org/knowm/xchart/style/MatlabTheme.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/MatlabTheme.java
@@ -16,11 +16,7 @@
  */
 package org.knowm.xchart.style;
 
-import java.awt.BasicStroke;
-import java.awt.Color;
-import java.awt.Font;
-import java.awt.Stroke;
-
+import org.knowm.xchart.Font;
 import org.knowm.xchart.style.PieStyler.AnnotationType;
 import org.knowm.xchart.style.Styler.LegendPosition;
 import org.knowm.xchart.style.colors.ChartColor;
@@ -29,10 +25,14 @@ import org.knowm.xchart.style.lines.MatlabSeriesLines;
 import org.knowm.xchart.style.markers.Marker;
 import org.knowm.xchart.style.markers.MatlabSeriesMarkers;
 
+import java.awt.BasicStroke;
+import java.awt.Color;
+import java.awt.Stroke;
+
 /**
  * @author timmolter
  */
-public class MatlabTheme implements Theme {
+public class MatlabTheme extends Theme {
 
   // Chart Style ///////////////////////////////
 

--- a/xchart/src/main/java/org/knowm/xchart/style/Styler.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/Styler.java
@@ -16,11 +16,11 @@
  */
 package org.knowm.xchart.style;
 
+import org.knowm.xchart.Font;
+import org.knowm.xchart.style.markers.Marker;
+
 import java.awt.BasicStroke;
 import java.awt.Color;
-import java.awt.Font;
-
-import org.knowm.xchart.style.markers.Marker;
 
 /**
  * The styler is used to manage all things related to styling of the vast number of Chart components

--- a/xchart/src/main/java/org/knowm/xchart/style/Theme.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/Theme.java
@@ -16,153 +16,153 @@
  */
 package org.knowm.xchart.style;
 
-import java.awt.Color;
-import java.awt.Font;
-import java.awt.Stroke;
-
+import org.knowm.xchart.Font;
 import org.knowm.xchart.style.PieStyler.AnnotationType;
 import org.knowm.xchart.style.Styler.LegendPosition;
 import org.knowm.xchart.style.colors.SeriesColors;
 import org.knowm.xchart.style.lines.SeriesLines;
 import org.knowm.xchart.style.markers.SeriesMarkers;
 
+import java.awt.Color;
+import java.awt.Stroke;
+
 /**
  * @author timmolter
  */
-public interface Theme extends SeriesMarkers, SeriesLines, SeriesColors {
+public abstract class Theme implements SeriesMarkers, SeriesLines, SeriesColors {
 
   // Chart Style ///////////////////////////////
 
-  public Color getChartBackgroundColor();
+  public abstract Color getChartBackgroundColor();
 
-  public Color getChartFontColor();
+  public abstract Color getChartFontColor();
 
-  public int getChartPadding();
+  public abstract int getChartPadding();
 
   // Chart Title ///////////////////////////////
 
-  public Font getChartTitleFont();
+  public abstract Font getChartTitleFont();
 
-  public boolean isChartTitleVisible();
+  public abstract boolean isChartTitleVisible();
 
-  public boolean isChartTitleBoxVisible();
+  public abstract boolean isChartTitleBoxVisible();
 
-  public Color getChartTitleBoxBackgroundColor();
+  public abstract Color getChartTitleBoxBackgroundColor();
 
-  public Color getChartTitleBoxBorderColor();
+  public abstract Color getChartTitleBoxBorderColor();
 
-  public int getChartTitlePadding();
+  public abstract int getChartTitlePadding();
 
   // Chart Legend ///////////////////////////////
 
-  public Font getLegendFont();
+  public abstract Font getLegendFont();
 
-  public boolean isLegendVisible();
+  public abstract boolean isLegendVisible();
 
-  public Color getLegendBackgroundColor();
+  public abstract Color getLegendBackgroundColor();
 
-  public Color getLegendBorderColor();
+  public abstract Color getLegendBorderColor();
 
-  public int getLegendPadding();
+  public abstract int getLegendPadding();
 
-  public int getLegendSeriesLineLength();
+  public abstract int getLegendSeriesLineLength();
 
-  public LegendPosition getLegendPosition();
+  public abstract LegendPosition getLegendPosition();
 
   // Chart Axes ///////////////////////////////
 
-  public boolean isXAxisTitleVisible();
+  public abstract boolean isXAxisTitleVisible();
 
-  public boolean isYAxisTitleVisible();
+  public abstract boolean isYAxisTitleVisible();
 
-  public Font getAxisTitleFont();
+  public abstract Font getAxisTitleFont();
 
-  public boolean isXAxisTicksVisible();
+  public abstract boolean isXAxisTicksVisible();
 
-  public boolean isYAxisTicksVisible();
+  public abstract boolean isYAxisTicksVisible();
 
-  public Font getAxisTickLabelsFont();
+  public abstract Font getAxisTickLabelsFont();
 
-  public int getAxisTickMarkLength();
+  public abstract int getAxisTickMarkLength();
 
-  public int getAxisTickPadding();
+  public abstract int getAxisTickPadding();
 
-  public Color getAxisTickMarksColor();
+  public abstract Color getAxisTickMarksColor();
 
-  public Stroke getAxisTickMarksStroke();
+  public abstract Stroke getAxisTickMarksStroke();
 
-  public Color getAxisTickLabelsColor();
+  public abstract Color getAxisTickLabelsColor();
 
-  public boolean isAxisTicksLineVisible();
+  public abstract boolean isAxisTicksLineVisible();
 
-  public boolean isAxisTicksMarksVisible();
+  public abstract boolean isAxisTicksMarksVisible();
 
-  public int getAxisTitlePadding();
+  public abstract int getAxisTitlePadding();
 
-  public int getXAxisTickMarkSpacingHint();
+  public abstract int getXAxisTickMarkSpacingHint();
 
-  public int getYAxisTickMarkSpacingHint();
+  public abstract int getYAxisTickMarkSpacingHint();
 
   // Chart Plot Area ///////////////////////////////
 
-  public boolean isPlotGridLinesVisible();
+  public abstract boolean isPlotGridLinesVisible();
 
-  public boolean isPlotGridVerticalLinesVisible();
+  public abstract boolean isPlotGridVerticalLinesVisible();
 
-  public boolean isPlotGridHorizontalLinesVisible();
+  public abstract boolean isPlotGridHorizontalLinesVisible();
 
-  public Color getPlotBackgroundColor();
+  public abstract Color getPlotBackgroundColor();
 
-  public Color getPlotBorderColor();
+  public abstract Color getPlotBorderColor();
 
-  public boolean isPlotBorderVisible();
+  public abstract boolean isPlotBorderVisible();
 
-  public Color getPlotGridLinesColor();
+  public abstract Color getPlotGridLinesColor();
 
-  public Stroke getPlotGridLinesStroke();
+  public abstract Stroke getPlotGridLinesStroke();
 
-  public boolean isPlotTicksMarksVisible();
+  public abstract boolean isPlotTicksMarksVisible();
 
-  public double getPlotContentSize();
+  public abstract double getPlotContentSize();
 
-  public int getPlotMargin();
+  public abstract int getPlotMargin();
 
   // Bar Charts ///////////////////////////////
 
-  public double getAvailableSpaceFill();
+  public abstract double getAvailableSpaceFill();
 
-  public boolean isOverlapped();
+  public abstract boolean isOverlapped();
 
   // Pie Charts ///////////////////////////////
 
-  public boolean isCircular();
+  public abstract boolean isCircular();
 
-  public double getStartAngleInDegrees();
+  public abstract double getStartAngleInDegrees();
 
-  public Font getPieFont();
+  public abstract Font getPieFont();
 
-  public double getAnnotationDistance();
+  public abstract double getAnnotationDistance();
 
-  public AnnotationType getAnnotationType();
+  public abstract AnnotationType getAnnotationType();
 
-  public boolean isDrawAllAnnotations();
+  public abstract boolean isDrawAllAnnotations();
 
-  public double getDonutThickness();
+  public abstract double getDonutThickness();
 
   // Line, Scatter, Area Charts ///////////////////////////////
 
-  public int getMarkerSize();
+  public abstract int getMarkerSize();
 
-  public boolean showMarkers();
+  public abstract boolean showMarkers();
 
   // Error Bars ///////////////////////////////
 
-  public Color getErrorBarsColor();
+  public abstract Color getErrorBarsColor();
 
-  public boolean isErrorBarsColorSeriesColor();
+  public abstract boolean isErrorBarsColorSeriesColor();
 
   // Annotations ///////////////////////////////
 
-  public Font getAnnotationFont();
+  public abstract Font getAnnotationFont();
 
 }

--- a/xchart/src/main/java/org/knowm/xchart/style/XChartTheme.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/XChartTheme.java
@@ -16,11 +16,7 @@
  */
 package org.knowm.xchart.style;
 
-import java.awt.BasicStroke;
-import java.awt.Color;
-import java.awt.Font;
-import java.awt.Stroke;
-
+import org.knowm.xchart.Font;
 import org.knowm.xchart.style.PieStyler.AnnotationType;
 import org.knowm.xchart.style.Styler.LegendPosition;
 import org.knowm.xchart.style.colors.ChartColor;
@@ -29,10 +25,14 @@ import org.knowm.xchart.style.lines.XChartSeriesLines;
 import org.knowm.xchart.style.markers.Marker;
 import org.knowm.xchart.style.markers.XChartSeriesMarkers;
 
+import java.awt.BasicStroke;
+import java.awt.Color;
+import java.awt.Stroke;
+
 /**
  * @author timmolter
  */
-public class XChartTheme implements Theme {
+public class XChartTheme extends Theme {
 
   // Chart Style ///////////////////////////////
 

--- a/xchart/src/main/java/org/knowm/xchart/style/markers/Circle.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/markers/Circle.java
@@ -16,7 +16,8 @@
  */
 package org.knowm.xchart.style.markers;
 
-import java.awt.Graphics2D;
+import org.knowm.xchart.graphics.Graphics;
+
 import java.awt.Shape;
 import java.awt.geom.Ellipse2D;
 
@@ -26,7 +27,7 @@ import java.awt.geom.Ellipse2D;
 public class Circle extends Marker {
 
   @Override
-  public void paint(Graphics2D g, double xOffset, double yOffset, int markerSize) {
+  public void paint(Graphics g, double xOffset, double yOffset, int markerSize) {
 
     g.setStroke(stroke);
     double halfSize = (double) markerSize / 2;

--- a/xchart/src/main/java/org/knowm/xchart/style/markers/Diamond.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/markers/Diamond.java
@@ -16,7 +16,8 @@
  */
 package org.knowm.xchart.style.markers;
 
-import java.awt.Graphics2D;
+import org.knowm.xchart.graphics.Graphics;
+
 import java.awt.geom.Path2D;
 
 /**
@@ -25,7 +26,7 @@ import java.awt.geom.Path2D;
 public class Diamond extends Marker {
 
   @Override
-  public void paint(Graphics2D g, double xOffset, double yOffset, int markerSize) {
+  public void paint(Graphics g, double xOffset, double yOffset, int markerSize) {
 
     g.setStroke(stroke);
 

--- a/xchart/src/main/java/org/knowm/xchart/style/markers/Marker.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/markers/Marker.java
@@ -16,8 +16,9 @@
  */
 package org.knowm.xchart.style.markers;
 
+import org.knowm.xchart.graphics.Graphics;
+
 import java.awt.BasicStroke;
-import java.awt.Graphics2D;
 
 /**
  * @author timmolter
@@ -26,6 +27,6 @@ public abstract class Marker {
 
   protected BasicStroke stroke = new BasicStroke(1, BasicStroke.CAP_BUTT, BasicStroke.JOIN_BEVEL);
 
-  public abstract void paint(Graphics2D g, double xOffset, double yOffset, int markerSize);
+  public abstract void paint(Graphics g, double xOffset, double yOffset, int markerSize);
 
 }

--- a/xchart/src/main/java/org/knowm/xchart/style/markers/None.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/markers/None.java
@@ -16,7 +16,7 @@
  */
 package org.knowm.xchart.style.markers;
 
-import java.awt.Graphics2D;
+import org.knowm.xchart.graphics.Graphics;
 
 /**
  * @author timmolter
@@ -24,7 +24,7 @@ import java.awt.Graphics2D;
 public class None extends Marker {
 
   @Override
-  public void paint(Graphics2D g, double xOffset, double yOffset, int markerSize) {
+  public void paint(Graphics g, double xOffset, double yOffset, int markerSize) {
 
     // do nothing!
 

--- a/xchart/src/main/java/org/knowm/xchart/style/markers/Square.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/markers/Square.java
@@ -16,7 +16,8 @@
  */
 package org.knowm.xchart.style.markers;
 
-import java.awt.Graphics2D;
+import org.knowm.xchart.graphics.Graphics;
+
 import java.awt.Shape;
 import java.awt.geom.Rectangle2D;
 
@@ -26,7 +27,7 @@ import java.awt.geom.Rectangle2D;
 public class Square extends Marker {
 
   @Override
-  public void paint(Graphics2D g, double xOffset, double yOffset, int markerSize) {
+  public void paint(Graphics g, double xOffset, double yOffset, int markerSize) {
 
     g.setStroke(stroke);
     double halfSize = (double) markerSize / 2;

--- a/xchart/src/main/java/org/knowm/xchart/style/markers/TriangleDown.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/markers/TriangleDown.java
@@ -16,7 +16,8 @@
  */
 package org.knowm.xchart.style.markers;
 
-import java.awt.Graphics2D;
+import org.knowm.xchart.graphics.Graphics;
+
 import java.awt.geom.Path2D;
 
 /**
@@ -25,7 +26,7 @@ import java.awt.geom.Path2D;
 public class TriangleDown extends Marker {
 
   @Override
-  public void paint(Graphics2D g, double xOffset, double yOffset, int markerSize) {
+  public void paint(Graphics g, double xOffset, double yOffset, int markerSize) {
 
     g.setStroke(stroke);
     double halfSize = (double) markerSize / 2;

--- a/xchart/src/main/java/org/knowm/xchart/style/markers/TriangleUp.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/markers/TriangleUp.java
@@ -16,7 +16,8 @@
  */
 package org.knowm.xchart.style.markers;
 
-import java.awt.Graphics2D;
+import org.knowm.xchart.graphics.Graphics;
+
 import java.awt.geom.Path2D;
 
 /**
@@ -25,7 +26,7 @@ import java.awt.geom.Path2D;
 public class TriangleUp extends Marker {
 
   @Override
-  public void paint(Graphics2D g, double xOffset, double yOffset, int markerSize) {
+  public void paint(Graphics g, double xOffset, double yOffset, int markerSize) {
 
     g.setStroke(stroke);
     double halfSize = (double) markerSize / 2;


### PR DESCRIPTION
👋 Hi! Sorry for the surprise big patch, I know it's poor form. This started as an experiment that I thought was too ambitious, and actually worked out, so I thought I should offer it!

This patch decouples the XChart rendering pipeline from AWT, so it can draw on any canvas that conforms to the XChart Graphics interface. My motivation was to get it working with `libgdx`, which uses OpenGL.

It's a substantial patch! In particular, XChart does lots of fancy text rendering math, which can no longer rely on AWT's TextLayout. Everywhere that needs to do calculations using font rendering properties now receives a RenderContext which it can use to get font metrics.

It's a breaking change, since it requires users to wrap the AWT graphics context in a wrapper interface.

I won't be offended if you don't want to take it! I'm also happy to discuss details if you'd like to revise it at all.