### PR TITLE
Feature: Optional sum (total value) in pie charts

### DIFF
--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/XChartDemo.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/XChartDemo.java
@@ -68,6 +68,7 @@ import org.knowm.xchart.demo.charts.pie.PieChart01;
 import org.knowm.xchart.demo.charts.pie.PieChart02;
 import org.knowm.xchart.demo.charts.pie.PieChart03;
 import org.knowm.xchart.demo.charts.pie.PieChart04;
+import org.knowm.xchart.demo.charts.pie.PieChart05;
 import org.knowm.xchart.demo.charts.realtime.RealtimeChart01;
 import org.knowm.xchart.demo.charts.realtime.RealtimeChart02;
 import org.knowm.xchart.demo.charts.realtime.RealtimeChart03;
@@ -288,6 +289,9 @@ public class XChartDemo extends JPanel implements TreeSelectionListener {
     category.add(defaultMutableTreeNode);
 
     defaultMutableTreeNode = new DefaultMutableTreeNode(new ChartInfo("PieChart04 - Pie Chart with Donut Style", new PieChart04().getChart()));
+    category.add(defaultMutableTreeNode);
+
+    defaultMutableTreeNode = new DefaultMutableTreeNode(new ChartInfo("PieChart05 - Pie Chart with Donut Style and Sum", new PieChart05().getChart()));
     category.add(defaultMutableTreeNode);
 
     // Line category

--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/pie/PieChart05.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/pie/PieChart05.java
@@ -22,6 +22,7 @@ import org.knowm.xchart.PieSeries.PieSeriesRenderStyle;
 import org.knowm.xchart.SwingWrapper;
 import org.knowm.xchart.demo.charts.ExampleChart;
 import org.knowm.xchart.style.PieStyler.AnnotationType;
+import org.knowm.xchart.style.colors.BaseSeriesColors;
 
 /**
  * Pie Chart with Donut Style and sum.
@@ -55,8 +56,10 @@ public class PieChart05 implements ExampleChart<PieChart> {
     chart.getStyler().setDefaultSeriesRenderStyle(PieSeriesRenderStyle.Donut);
     chart.getStyler().setDecimalPattern("#");
 
+    chart.getStyler().setSeriesColors(new BaseSeriesColors().getSeriesColors());
+
     chart.getStyler().setSumVisible(true);
-    chart.getStyler().setSumFont(chart.getStyler().getSumFont().deriveFont(Float.valueOf(20)));
+    chart.getStyler().setSumFontSize(20f);
 
     // Series
     chart.addSeries("A", 22);

--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/pie/PieChart05.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/pie/PieChart05.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright 2015-2017 Knowm Inc. (http://knowm.org) and contributors.
+ * Copyright 2011-2015 Xeiam LLC (http://xeiam.com) and contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.knowm.xchart.demo.charts.pie;
+
+import org.knowm.xchart.PieChart;
+import org.knowm.xchart.PieChartBuilder;
+import org.knowm.xchart.PieSeries.PieSeriesRenderStyle;
+import org.knowm.xchart.SwingWrapper;
+import org.knowm.xchart.demo.charts.ExampleChart;
+import org.knowm.xchart.style.PieStyler.AnnotationType;
+
+/**
+ * Pie Chart with Donut Style and sum.
+ * <p>
+ * Demonstrates the following:
+ * <ul>
+ * <li>Donut Chart
+ * <li>PieChartBuilder
+ * <li>XChart Theme
+ */
+public class PieChart05 implements ExampleChart<PieChart> {
+
+  public static void main(String[] args) {
+
+    ExampleChart<PieChart> exampleChart = new PieChart05();
+    PieChart chart = exampleChart.getChart();
+    new SwingWrapper<PieChart>(chart).displayChart();
+  }
+
+  @Override
+  public PieChart getChart() {
+
+    // Create Chart
+    PieChart chart = new PieChartBuilder().width(800).height(600).title("Pie Chart with Donut Style and Sum").build();
+
+    // Customize Chart
+    chart.getStyler().setLegendVisible(false);
+    chart.getStyler().setAnnotationType(AnnotationType.Label);
+    chart.getStyler().setAnnotationDistance(.82);
+    chart.getStyler().setPlotContentSize(.9);
+    chart.getStyler().setDefaultSeriesRenderStyle(PieSeriesRenderStyle.Donut);
+    chart.getStyler().setDecimalPattern("#");
+
+    chart.getStyler().setSumVisible(true);
+    chart.getStyler().setSumFont(chart.getStyler().getSumFont().deriveFont(Float.valueOf(20)));
+
+    // Series
+    chart.addSeries("A", 22);
+    chart.addSeries("B", 10);
+    chart.addSeries("C", 34);
+    chart.addSeries("D", 22);
+    chart.addSeries("E", 29);
+    chart.addSeries("F", 40);
+
+    return chart;
+  }
+}

--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/theme/MyCustomTheme.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/theme/MyCustomTheme.java
@@ -21,9 +21,7 @@ import java.awt.Color;
 import java.awt.Font;
 import java.awt.Stroke;
 
-import org.knowm.xchart.style.PieStyler.AnnotationType;
-import org.knowm.xchart.style.Styler.LegendPosition;
-import org.knowm.xchart.style.Theme;
+import org.knowm.xchart.style.AbstractBaseTheme;
 import org.knowm.xchart.style.colors.ChartColor;
 import org.knowm.xchart.style.lines.XChartSeriesLines;
 import org.knowm.xchart.style.markers.Marker;
@@ -32,9 +30,15 @@ import org.knowm.xchart.style.markers.XChartSeriesMarkers;
 /**
  * @author timmolter
  */
-public class MyCustomTheme implements Theme {
+public class MyCustomTheme extends AbstractBaseTheme {
 
   // Chart Style ///////////////////////////////
+
+  @Override
+  public Font getBaseFont() {
+
+	return new Font(Font.SERIF, Font.PLAIN, 10);
+  }
 
   @Override
   public Color getChartBackgroundColor() {
@@ -77,13 +81,7 @@ public class MyCustomTheme implements Theme {
   @Override
   public Font getChartTitleFont() {
 
-    return new Font(Font.SANS_SERIF, Font.BOLD, 18);
-  }
-
-  @Override
-  public boolean isChartTitleVisible() {
-
-    return true;
+	return getBaseFont().deriveFont(Font.BOLD).deriveFont(18f);
   }
 
   @Override
@@ -104,117 +102,9 @@ public class MyCustomTheme implements Theme {
     return ChartColor.getAWTColor(ChartColor.GREY);
   }
 
-  @Override
-  public int getChartTitlePadding() {
-
-    return 5;
-  }
-
   // Chart Legend ///////////////////////////////
 
-  @Override
-  public Font getLegendFont() {
-
-    return new Font(Font.SANS_SERIF, Font.PLAIN, 11);
-  }
-
-  @Override
-  public boolean isLegendVisible() {
-
-    return true;
-  }
-
-  @Override
-  public Color getLegendBackgroundColor() {
-
-    return ChartColor.getAWTColor(ChartColor.WHITE);
-  }
-
-  @Override
-  public Color getLegendBorderColor() {
-
-    return ChartColor.getAWTColor(ChartColor.DARK_GREY);
-  }
-
-  @Override
-  public int getLegendPadding() {
-
-    return 10;
-  }
-
-  @Override
-  public int getLegendSeriesLineLength() {
-
-    return 24;
-  }
-
-  @Override
-  public LegendPosition getLegendPosition() {
-
-    return LegendPosition.OutsideE;
-  }
-
   // Chart Axes ///////////////////////////////
-
-  @Override
-  public boolean isXAxisTitleVisible() {
-
-    return true;
-  }
-
-  @Override
-  public boolean isYAxisTitleVisible() {
-
-    return true;
-  }
-
-  @Override
-  public Font getAxisTitleFont() {
-
-    return new Font(Font.SANS_SERIF, Font.BOLD, 12);
-  }
-
-  @Override
-  public boolean isXAxisTicksVisible() {
-
-    return true;
-  }
-
-  @Override
-  public boolean isYAxisTicksVisible() {
-
-    return true;
-  }
-
-  @Override
-  public Font getAxisTickLabelsFont() {
-
-    return new Font(Font.SANS_SERIF, Font.BOLD, 12);
-  }
-
-  @Override
-  public int getAxisTickMarkLength() {
-
-    return 3;
-  }
-
-  @Override
-  public int getAxisTickPadding() {
-
-    return 4;
-  }
-
-  @Override
-  public int getPlotMargin() {
-
-    return 4;
-  }
-
-  @Override
-  public Color getAxisTickMarksColor() {
-
-    return ChartColor.getAWTColor(ChartColor.DARK_GREY);
-  }
 
   @Override
   public Stroke getAxisTickMarksStroke() {
@@ -222,79 +112,7 @@ public class MyCustomTheme implements Theme {
     return new BasicStroke(1, BasicStroke.CAP_BUTT, BasicStroke.JOIN_BEVEL, 10.0f, new float[]{3.0f, 0.0f}, 0.0f);
   }
 
-  @Override
-  public Color getAxisTickLabelsColor() {
-
-    return ChartColor.getAWTColor(ChartColor.BLACK);
-  }
-
-  @Override
-  public boolean isAxisTicksLineVisible() {
-
-    return true;
-  }
-
-  @Override
-  public boolean isAxisTicksMarksVisible() {
-
-    return true;
-  }
-
-  @Override
-  public int getAxisTitlePadding() {
-
-    return 10;
-  }
-
-  @Override
-  public int getXAxisTickMarkSpacingHint() {
-
-    return 74;
-  }
-
-  @Override
-  public int getYAxisTickMarkSpacingHint() {
-
-    return 44;
-  }
-
   // Chart Plot Area ///////////////////////////////
-
-  @Override
-  public boolean isPlotGridLinesVisible() {
-
-    return true;
-  }
-
-  @Override
-  public boolean isPlotGridVerticalLinesVisible() {
-
-    return true;
-  }
-
-  @Override
-  public boolean isPlotGridHorizontalLinesVisible() {
-
-    return true;
-  }
-
-  @Override
-  public Color getPlotBackgroundColor() {
-
-    return ChartColor.getAWTColor(ChartColor.WHITE);
-  }
-
-  @Override
-  public Color getPlotBorderColor() {
-
-    return ChartColor.getAWTColor(ChartColor.DARK_GREY);
-  }
-
-  @Override
-  public boolean isPlotBorderVisible() {
-
-    return true;
-  }
 
   @Override
   public boolean isPlotTicksMarksVisible() {
@@ -303,92 +121,14 @@ public class MyCustomTheme implements Theme {
   }
 
   @Override
-  public Color getPlotGridLinesColor() {
-
-    return ChartColor.getAWTColor(ChartColor.GREY);
-  }
-
-  @Override
   public Stroke getPlotGridLinesStroke() {
 
     return new BasicStroke(0.25f, BasicStroke.CAP_BUTT, BasicStroke.JOIN_BEVEL, 10.0f, new float[]{3.0f, 3.0f}, 0.0f);
   }
 
-  @Override
-  public double getPlotContentSize() {
-
-    return .92;
-  }
-
   // Category Charts ///////////////////////////////
 
-  @Override
-  public double getAvailableSpaceFill() {
-
-    return 0.9;
-  }
-
-  @Override
-  public boolean isOverlapped() {
-
-    return false;
-  }
-
   // Pie Charts ///////////////////////////////
-
-  @Override
-  public boolean isCircular() {
-
-    return true;
-  }
-
-  @Override
-  public double getStartAngleInDegrees() {
-
-    return 0;
-  }
-
-  @Override
-  public Font getPieFont() {
-
-    return new Font(Font.SANS_SERIF, Font.PLAIN, 15);
-  }
-
-  @Override
-  public double getAnnotationDistance() {
-
-    return .67;
-  }
-
-  @Override
-  public AnnotationType getAnnotationType() {
-
-    return AnnotationType.Percentage;
-  }
-
-  @Override
-  public boolean isDrawAllAnnotations() {
-
-    return false;
-  }
-
-  @Override
-  public double getDonutThickness() {
-
-    return .33;
-  }
-
-  @Override
-  public boolean isSumVisible() {
-
-  	return false;
-  }
-
-  @Override
-  public Font getSumFont() {
-
-    return new Font(Font.SANS_SERIF, Font.PLAIN, 12);
-  }
 
   // Line, Scatter, Area Charts ///////////////////////////////
 
@@ -398,32 +138,8 @@ public class MyCustomTheme implements Theme {
     return 16;
   }
 
-  @Override
-  public boolean showMarkers() {
-
-    return true;
-  }
-
   // Error Bars ///////////////////////////////
 
-  @Override
-  public Color getErrorBarsColor() {
-
-    return ChartColor.getAWTColor(ChartColor.BLACK);
-  }
-
-  @Override
-  public boolean isErrorBarsColorSeriesColor() {
-
-    return false;
-  }
-
   // Annotations ///////////////////////////////
-
-  @Override
-  public Font getAnnotationFont() {
-
-    return new Font(Font.SANS_SERIF, Font.PLAIN, 12);
-  }
 
 }

--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/theme/MyCustomTheme.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/theme/MyCustomTheme.java
@@ -378,6 +378,18 @@ public class MyCustomTheme implements Theme {
     return .33;
   }
 
+  @Override
+  public boolean isSumVisible() {
+
+  	return false;
+  }
+
+  @Override
+  public Font getSumFont() {
+
+    return new Font(Font.SANS_SERIF, Font.PLAIN, 12);
+  }
+
   // Line, Scatter, Area Charts ///////////////////////////////
 
   @Override
@@ -413,4 +425,5 @@ public class MyCustomTheme implements Theme {
 
     return new Font(Font.SANS_SERIF, Font.PLAIN, 12);
   }
+
 }

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Pie.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Pie.java
@@ -92,6 +92,32 @@ public class PlotContent_Pie<ST extends Styler, S extends Series> extends PlotCo
       total += series.getValue().doubleValue();
     }
 
+    // draw total value if visible
+    if (pieStyler.isSumVisible()) {
+    	DecimalFormat totalDf = (pieStyler.getDecimalPattern() == null) ? df : new DecimalFormat(pieStyler.getDecimalPattern());
+
+    	String annotation = totalDf.format(total);
+
+        TextLayout textLayout = new TextLayout(annotation, pieStyler.getSumFont(), new FontRenderContext(null, true, false));
+        Shape shape = textLayout.getOutline(null);
+        g.setColor(pieStyler.getChartFontColor());
+
+        // compute center
+        Rectangle2D annotationRectangle = textLayout.getBounds();
+        double xCenter = pieBounds.getX() + pieBounds.getWidth() / 2 - annotationRectangle.getWidth() / 2;
+        double yCenter = pieBounds.getY() + pieBounds.getHeight() / 2 + annotationRectangle.getHeight() / 2;
+
+        // set text
+        AffineTransform orig = g.getTransform();
+        AffineTransform at = new AffineTransform();
+
+        at.translate(xCenter, yCenter);
+        g.transform(at);
+        g.fill(shape);
+        g.setTransform(orig);
+
+    }
+
     // draw pie slices
     // double curValue = 0.0;
     // double curValue = 0.0;

--- a/xchart/src/main/java/org/knowm/xchart/style/AbstractBaseTheme.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/AbstractBaseTheme.java
@@ -1,0 +1,460 @@
+/**
+ * Copyright 2015-2017 Knowm Inc. (http://knowm.org) and contributors.
+ * Copyright 2011-2015 Xeiam LLC (http://xeiam.com) and contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.knowm.xchart.style;
+
+import java.awt.BasicStroke;
+import java.awt.Color;
+import java.awt.Font;
+import java.awt.Stroke;
+
+import org.knowm.xchart.style.PieStyler.AnnotationType;
+import org.knowm.xchart.style.Styler.LegendPosition;
+import org.knowm.xchart.style.colors.BaseSeriesColors;
+import org.knowm.xchart.style.colors.ChartColor;
+import org.knowm.xchart.style.lines.BaseSeriesLines;
+import org.knowm.xchart.style.markers.BaseSeriesMarkers;
+import org.knowm.xchart.style.markers.Marker;
+
+/**
+ * @author timmolter
+ * @author ekleinod
+ */
+public abstract class AbstractBaseTheme implements Theme {
+
+  public static final Font BASE_FONT = new Font(Font.SANS_SERIF, Font.PLAIN, 10);
+
+  // Chart Style ///////////////////////////////
+
+  @Override
+  public Font getBaseFont() {
+
+	return BASE_FONT;
+  }
+
+  @Override
+  public Color getChartBackgroundColor() {
+
+    return ChartColor.getAWTColor(ChartColor.WHITE);
+  }
+
+  @Override
+  public Color getChartFontColor() {
+
+    return ChartColor.getAWTColor(ChartColor.BLACK);
+  }
+
+  @Override
+  public int getChartPadding() {
+
+    return 10;
+  }
+
+  // SeriesMarkers, SeriesLines, SeriesColors ///////////////////////////////
+
+  @Override
+  public Color[] getSeriesColors() {
+
+    return new BaseSeriesColors().getSeriesColors();
+  }
+
+  @Override
+  public Marker[] getSeriesMarkers() {
+
+    return new BaseSeriesMarkers().getSeriesMarkers();
+  }
+
+  @Override
+  public BasicStroke[] getSeriesLines() {
+
+    return new BaseSeriesLines().getSeriesLines();
+  }
+
+  // Chart Title ///////////////////////////////
+
+  /**
+   * Base font, bold, size 14.
+   */
+  @Override
+  public Font getChartTitleFont() {
+
+	return getBaseFont().deriveFont(Font.BOLD).deriveFont(14f);
+  }
+
+  @Override
+  public boolean isChartTitleVisible() {
+
+    return true;
+  }
+
+  @Override
+  public boolean isChartTitleBoxVisible() {
+
+    return true;
+  }
+
+  @Override
+  public Color getChartTitleBoxBackgroundColor() {
+
+    return ChartColor.getAWTColor(ChartColor.WHITE);
+  }
+
+  @Override
+  public Color getChartTitleBoxBorderColor() {
+
+    return ChartColor.getAWTColor(ChartColor.WHITE);
+  }
+
+  @Override
+  public int getChartTitlePadding() {
+
+    return 5;
+  }
+
+  // Chart Legend ///////////////////////////////
+
+  /**
+   * Base font, size 11.
+   */
+  @Override
+  public Font getLegendFont() {
+
+	return getBaseFont().deriveFont(11f);
+  }
+
+  @Override
+  public boolean isLegendVisible() {
+
+    return true;
+  }
+
+  @Override
+  public Color getLegendBackgroundColor() {
+
+    return ChartColor.getAWTColor(ChartColor.WHITE);
+  }
+
+  @Override
+  public Color getLegendBorderColor() {
+
+    return ChartColor.getAWTColor(ChartColor.DARK_GREY);
+  }
+
+  @Override
+  public int getLegendPadding() {
+
+    return 10;
+  }
+
+  @Override
+  public int getLegendSeriesLineLength() {
+
+    return 24;
+  }
+
+  @Override
+  public LegendPosition getLegendPosition() {
+
+    return LegendPosition.OutsideE;
+  }
+
+  // Chart Axes ///////////////////////////////
+
+  @Override
+  public boolean isXAxisTitleVisible() {
+
+    return true;
+  }
+
+  @Override
+  public boolean isYAxisTitleVisible() {
+
+    return true;
+  }
+
+  /**
+   * Base font, bold, size 12.
+   */
+  @Override
+  public Font getAxisTitleFont() {
+
+    return getBaseFont().deriveFont(Font.BOLD).deriveFont(12f);
+  }
+
+  @Override
+  public boolean isXAxisTicksVisible() {
+
+    return true;
+  }
+
+  @Override
+  public boolean isYAxisTicksVisible() {
+
+    return true;
+  }
+
+  /**
+   * Axis title font.
+   */
+  @Override
+  public Font getAxisTickLabelsFont() {
+
+	return getAxisTitleFont();
+  }
+
+  @Override
+  public int getAxisTickMarkLength() {
+
+    return 3;
+  }
+
+  @Override
+  public int getAxisTickPadding() {
+
+    return 4;
+  }
+
+  @Override
+  public Color getAxisTickMarksColor() {
+
+	  return ChartColor.getAWTColor(ChartColor.DARK_GREY);
+  }
+
+  @Override
+  public Stroke getAxisTickMarksStroke() {
+
+    return new BasicStroke(1.0f);
+  }
+
+  @Override
+  public Color getAxisTickLabelsColor() {
+
+    return ChartColor.getAWTColor(ChartColor.BLACK);
+  }
+
+  @Override
+  public boolean isAxisTicksLineVisible() {
+
+    return true;
+  }
+
+  @Override
+  public boolean isAxisTicksMarksVisible() {
+
+    return true;
+  }
+
+  @Override
+  public int getAxisTitlePadding() {
+
+    return 10;
+  }
+
+  @Override
+  public int getXAxisTickMarkSpacingHint() {
+
+    return 74;
+  }
+
+  @Override
+  public int getYAxisTickMarkSpacingHint() {
+
+    return 44;
+  }
+
+  // Chart Plot Area ///////////////////////////////
+
+  @Override
+  public boolean isPlotGridLinesVisible() {
+
+    return true;
+  }
+
+  @Override
+  public boolean isPlotGridVerticalLinesVisible() {
+
+    return true;
+  }
+
+  @Override
+  public boolean isPlotGridHorizontalLinesVisible() {
+
+    return true;
+  }
+
+  @Override
+  public Color getPlotBackgroundColor() {
+
+    return ChartColor.getAWTColor(ChartColor.WHITE);
+  }
+
+  @Override
+  public Color getPlotBorderColor() {
+
+    return ChartColor.getAWTColor(ChartColor.DARK_GREY);
+  }
+
+  @Override
+  public boolean isPlotBorderVisible() {
+
+    return true;
+  }
+
+  @Override
+  public boolean isPlotTicksMarksVisible() {
+
+    return true;
+  }
+
+  @Override
+  public Color getPlotGridLinesColor() {
+
+    return ChartColor.getAWTColor(ChartColor.GREY);
+  }
+
+  @Override
+  public Stroke getPlotGridLinesStroke() {
+
+    return new BasicStroke(1.0f, BasicStroke.CAP_BUTT, BasicStroke.JOIN_BEVEL, 10.0f, new float[]{3.0f, 5.0f}, 0.0f);
+  }
+
+  @Override
+  public double getPlotContentSize() {
+
+    return .92;
+  }
+
+  @Override
+  public int getPlotMargin() {
+
+    return 4;
+  }
+
+  // Category Charts ///////////////////////////////
+
+  @Override
+  public double getAvailableSpaceFill() {
+
+    return 0.9;
+  }
+
+  @Override
+  public boolean isOverlapped() {
+
+    return false;
+  }
+
+  // Pie Charts ///////////////////////////////
+
+  @Override
+  public boolean isCircular() {
+
+    return true;
+  }
+
+  @Override
+  public double getStartAngleInDegrees() {
+
+    return 0;
+  }
+
+  /**
+   * Base font, size 15.
+   */
+  @Override
+  public Font getPieFont() {
+
+    return getBaseFont().deriveFont(15f);
+  }
+
+  @Override
+  public double getAnnotationDistance() {
+
+    return .67;
+  }
+
+  @Override
+  public AnnotationType getAnnotationType() {
+
+    return AnnotationType.Percentage;
+  }
+
+  @Override
+  public boolean isDrawAllAnnotations() {
+
+    return false;
+  }
+
+  @Override
+  public double getDonutThickness() {
+
+    return .33;
+  }
+
+  @Override
+  public boolean isSumVisible() {
+
+  	return false;
+  }
+
+  /**
+   * Annotations font.
+   */
+  @Override
+  public Font getSumFont() {
+
+    return getAnnotationFont();
+  }
+
+  // Line, Scatter, Area Charts ///////////////////////////////
+
+  @Override
+  public int getMarkerSize() {
+
+    return 8;
+  }
+
+  @Override
+  public boolean showMarkers() {
+
+    return true;
+  }
+
+  // Error Bars ///////////////////////////////
+
+  @Override
+  public Color getErrorBarsColor() {
+
+    return ChartColor.getAWTColor(ChartColor.BLACK);
+  }
+
+  @Override
+  public boolean isErrorBarsColorSeriesColor() {
+
+    return false;
+  }
+
+  // Annotations ///////////////////////////////
+
+  /**
+   * Pie font, size 12.
+   */
+  @Override
+  public Font getAnnotationFont() {
+
+    return getPieFont().deriveFont(12f);
+  }
+}

--- a/xchart/src/main/java/org/knowm/xchart/style/GGPlot2Theme.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/GGPlot2Theme.java
@@ -378,6 +378,18 @@ public class GGPlot2Theme implements Theme {
     return .25;
   }
 
+  @Override
+  public boolean isSumVisible() {
+
+  	return false;
+  }
+
+  @Override
+  public Font getSumFont() {
+
+    return new Font(Font.SANS_SERIF, Font.PLAIN, 12);
+  }
+
   // Line, Scatter, Area Charts ///////////////////////////////
 
   @Override

--- a/xchart/src/main/java/org/knowm/xchart/style/GGPlot2Theme.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/GGPlot2Theme.java
@@ -22,7 +22,6 @@ import java.awt.Font;
 import java.awt.Stroke;
 
 import org.knowm.xchart.style.PieStyler.AnnotationType;
-import org.knowm.xchart.style.Styler.LegendPosition;
 import org.knowm.xchart.style.colors.ChartColor;
 import org.knowm.xchart.style.colors.GGPlot2SeriesColors;
 import org.knowm.xchart.style.lines.GGPlot2SeriesLines;
@@ -32,27 +31,11 @@ import org.knowm.xchart.style.markers.Marker;
 /**
  * @author timmolter
  */
-public class GGPlot2Theme implements Theme {
+public class GGPlot2Theme extends AbstractBaseTheme {
 
   // Chart Style ///////////////////////////////
 
-  @Override
-  public Color getChartBackgroundColor() {
-
-    return ChartColor.getAWTColor(ChartColor.WHITE);
-  }
-
-  @Override
-  public Color getChartFontColor() {
-
-    return ChartColor.getAWTColor(ChartColor.BLACK);
-  }
-
-  @Override
-  public int getChartPadding() {
-
-    return 10;
-  }
+  // SeriesMarkers, SeriesLines, SeriesColors ///////////////////////////////
 
   @Override
   public Marker[] getSeriesMarkers() {
@@ -77,19 +60,7 @@ public class GGPlot2Theme implements Theme {
   @Override
   public Font getChartTitleFont() {
 
-    return new Font(Font.SANS_SERIF, Font.PLAIN, 14);
-  }
-
-  @Override
-  public boolean isChartTitleVisible() {
-
-    return true;
-  }
-
-  @Override
-  public boolean isChartTitleBoxVisible() {
-
-    return true;
+    return getBaseFont().deriveFont(14f);
   }
 
   @Override
@@ -104,30 +75,12 @@ public class GGPlot2Theme implements Theme {
     return ChartColor.getAWTColor(ChartColor.GREY);
   }
 
-  @Override
-  public int getChartTitlePadding() {
-
-    return 5;
-  }
-
   // Chart Legend ///////////////////////////////
 
   @Override
   public Font getLegendFont() {
 
-    return new Font(Font.SANS_SERIF, Font.PLAIN, 14);
-  }
-
-  @Override
-  public boolean isLegendVisible() {
-
-    return true;
-  }
-
-  @Override
-  public Color getLegendBackgroundColor() {
-
-    return ChartColor.getAWTColor(ChartColor.WHITE);
+	return getBaseFont().deriveFont(14f);
   }
 
   @Override
@@ -136,60 +89,18 @@ public class GGPlot2Theme implements Theme {
     return ChartColor.getAWTColor(ChartColor.WHITE);
   }
 
-  @Override
-  public int getLegendPadding() {
-
-    return 10;
-  }
-
-  @Override
-  public int getLegendSeriesLineLength() {
-
-    return 24;
-  }
-
-  @Override
-  public LegendPosition getLegendPosition() {
-
-    return LegendPosition.OutsideE;
-  }
-
   // Chart Axes ///////////////////////////////
-
-  @Override
-  public boolean isXAxisTitleVisible() {
-
-    return true;
-  }
-
-  @Override
-  public boolean isYAxisTitleVisible() {
-
-    return true;
-  }
 
   @Override
   public Font getAxisTitleFont() {
 
-    return new Font(Font.SANS_SERIF, Font.PLAIN, 14);
-  }
-
-  @Override
-  public boolean isXAxisTicksVisible() {
-
-    return true;
-  }
-
-  @Override
-  public boolean isYAxisTicksVisible() {
-
-    return true;
+    return getBaseFont().deriveFont(14f);
   }
 
   @Override
   public Font getAxisTickLabelsFont() {
 
-    return new Font(Font.SANS_SERIF, Font.BOLD, 13);
+    return getBaseFont().deriveFont(Font.BOLD).deriveFont(13f);
   }
 
   @Override
@@ -205,30 +116,6 @@ public class GGPlot2Theme implements Theme {
   }
 
   @Override
-  public int getPlotMargin() {
-
-    return 0;
-  }
-
-  @Override
-  public boolean isAxisTicksLineVisible() {
-
-    return false;
-  }
-
-  @Override
-  public boolean isAxisTicksMarksVisible() {
-
-    return true;
-  }
-
-  @Override
-  public Color getAxisTickMarksColor() {
-
-    return ChartColor.getAWTColor(ChartColor.DARK_GREY);
-  }
-
-  @Override
   public Stroke getAxisTickMarksStroke() {
 
     return new BasicStroke(1.5f);
@@ -241,42 +128,12 @@ public class GGPlot2Theme implements Theme {
   }
 
   @Override
-  public int getAxisTitlePadding() {
+  public boolean isAxisTicksLineVisible() {
 
-    return 10;
-  }
-
-  @Override
-  public int getXAxisTickMarkSpacingHint() {
-
-    return 74;
-  }
-
-  @Override
-  public int getYAxisTickMarkSpacingHint() {
-
-    return 44;
+	  return false;
   }
 
   // Chart Plot Area ///////////////////////////////
-
-  @Override
-  public boolean isPlotGridLinesVisible() {
-
-    return true;
-  }
-
-  @Override
-  public boolean isPlotGridVerticalLinesVisible() {
-
-    return true;
-  }
-
-  @Override
-  public boolean isPlotGridHorizontalLinesVisible() {
-
-    return true;
-  }
 
   @Override
   public Color getPlotBackgroundColor() {
@@ -315,50 +172,14 @@ public class GGPlot2Theme implements Theme {
   }
 
   @Override
-  public double getPlotContentSize() {
-
-    return .92;
-  }
-
-  // Category Charts ///////////////////////////////
-
-  @Override
-  public double getAvailableSpaceFill() {
-
-    return 0.9;
-  }
-
-  @Override
-  public boolean isOverlapped() {
-
-    return false;
-  }
-
-  // Pie Charts ///////////////////////////////
-
-  @Override
-  public boolean isCircular() {
-
-    return true;
-  }
-
-  @Override
-  public double getStartAngleInDegrees() {
+  public int getPlotMargin() {
 
     return 0;
   }
 
-  @Override
-  public Font getPieFont() {
+  // Category Charts ///////////////////////////////
 
-    return new Font(Font.SANS_SERIF, Font.PLAIN, 15);
-  }
-
-  @Override
-  public double getAnnotationDistance() {
-
-    return .67;
-  }
+  // Pie Charts ///////////////////////////////
 
   @Override
   public AnnotationType getAnnotationType() {
@@ -367,42 +188,12 @@ public class GGPlot2Theme implements Theme {
   }
 
   @Override
-  public boolean isDrawAllAnnotations() {
-
-    return false;
-  }
-
-  @Override
   public double getDonutThickness() {
 
     return .25;
   }
 
-  @Override
-  public boolean isSumVisible() {
-
-  	return false;
-  }
-
-  @Override
-  public Font getSumFont() {
-
-    return new Font(Font.SANS_SERIF, Font.PLAIN, 12);
-  }
-
   // Line, Scatter, Area Charts ///////////////////////////////
-
-  @Override
-  public int getMarkerSize() {
-
-    return 8;
-  }
-
-  @Override
-  public boolean showMarkers() {
-
-    return true;
-  }
 
   // Error Bars ///////////////////////////////
 
@@ -412,17 +203,6 @@ public class GGPlot2Theme implements Theme {
     return ChartColor.getAWTColor(ChartColor.DARK_GREY);
   }
 
-  @Override
-  public boolean isErrorBarsColorSeriesColor() {
-
-    return false;
-  }
-
   // Annotations ///////////////////////////////
 
-  @Override
-  public Font getAnnotationFont() {
-
-    return new Font(Font.SANS_SERIF, Font.PLAIN, 12);
-  }
 }

--- a/xchart/src/main/java/org/knowm/xchart/style/MatlabTheme.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/MatlabTheme.java
@@ -22,7 +22,6 @@ import java.awt.Font;
 import java.awt.Stroke;
 
 import org.knowm.xchart.style.PieStyler.AnnotationType;
-import org.knowm.xchart.style.Styler.LegendPosition;
 import org.knowm.xchart.style.colors.ChartColor;
 import org.knowm.xchart.style.colors.MatlabSeriesColors;
 import org.knowm.xchart.style.lines.MatlabSeriesLines;
@@ -32,27 +31,11 @@ import org.knowm.xchart.style.markers.MatlabSeriesMarkers;
 /**
  * @author timmolter
  */
-public class MatlabTheme implements Theme {
+public class MatlabTheme extends AbstractBaseTheme {
 
   // Chart Style ///////////////////////////////
 
-  @Override
-  public Color getChartBackgroundColor() {
-
-    return ChartColor.getAWTColor(ChartColor.WHITE);
-  }
-
-  @Override
-  public Color getChartFontColor() {
-
-    return ChartColor.getAWTColor(ChartColor.BLACK);
-  }
-
-  @Override
-  public int getChartPadding() {
-
-    return 10;
-  }
+  // SeriesMarkers, SeriesLines, SeriesColors ///////////////////////////////
 
   @Override
   public Marker[] getSeriesMarkers() {
@@ -75,60 +58,12 @@ public class MatlabTheme implements Theme {
   // Chart Title ///////////////////////////////
 
   @Override
-  public Font getChartTitleFont() {
-
-    return new Font(Font.SANS_SERIF, Font.BOLD, 14);
-  }
-
-  @Override
-  public boolean isChartTitleVisible() {
-
-    return true;
-  }
-
-  @Override
   public boolean isChartTitleBoxVisible() {
 
     return false;
   }
 
-  @Override
-  public Color getChartTitleBoxBackgroundColor() {
-
-    return ChartColor.getAWTColor(ChartColor.WHITE);
-  }
-
-  @Override
-  public Color getChartTitleBoxBorderColor() {
-
-    return ChartColor.getAWTColor(ChartColor.WHITE);
-  }
-
-  @Override
-  public int getChartTitlePadding() {
-
-    return 5;
-  }
-
   // Chart Legend ///////////////////////////////
-
-  @Override
-  public Font getLegendFont() {
-
-    return new Font(Font.SANS_SERIF, Font.PLAIN, 11);
-  }
-
-  @Override
-  public boolean isLegendVisible() {
-
-    return true;
-  }
-
-  @Override
-  public Color getLegendBackgroundColor() {
-
-    return ChartColor.getAWTColor(ChartColor.WHITE);
-  }
 
   @Override
   public Color getLegendBorderColor() {
@@ -136,78 +71,18 @@ public class MatlabTheme implements Theme {
     return ChartColor.getAWTColor(ChartColor.BLACK);
   }
 
-  @Override
-  public int getLegendPadding() {
-
-    return 10;
-  }
-
-  @Override
-  public int getLegendSeriesLineLength() {
-
-    return 24;
-  }
-
-  @Override
-  public LegendPosition getLegendPosition() {
-
-    return LegendPosition.OutsideE;
-  }
-
   // Chart Axes ///////////////////////////////
-
-  @Override
-  public boolean isXAxisTitleVisible() {
-
-    return true;
-  }
-
-  @Override
-  public boolean isYAxisTitleVisible() {
-
-    return true;
-  }
 
   @Override
   public Font getAxisTitleFont() {
 
-    return new Font(Font.SANS_SERIF, Font.PLAIN, 12);
-  }
-
-  @Override
-  public boolean isXAxisTicksVisible() {
-
-    return true;
-  }
-
-  @Override
-  public boolean isYAxisTicksVisible() {
-
-    return true;
-  }
-
-  @Override
-  public Font getAxisTickLabelsFont() {
-
-    return new Font(Font.SANS_SERIF, Font.PLAIN, 12);
+    return getBaseFont().deriveFont(12f);
   }
 
   @Override
   public int getAxisTickMarkLength() {
 
     return 5;
-  }
-
-  @Override
-  public int getAxisTickPadding() {
-
-    return 4;
-  }
-
-  @Override
-  public int getPlotMargin() {
-
-    return 3;
   }
 
   @Override
@@ -223,12 +98,6 @@ public class MatlabTheme implements Theme {
   }
 
   @Override
-  public Color getAxisTickLabelsColor() {
-
-    return ChartColor.getAWTColor(ChartColor.BLACK);
-  }
-
-  @Override
   public boolean isAxisTicksLineVisible() {
 
     return false;
@@ -240,66 +109,12 @@ public class MatlabTheme implements Theme {
     return false;
   }
 
-  @Override
-  public int getAxisTitlePadding() {
-
-    return 10;
-  }
-
-  @Override
-  public int getXAxisTickMarkSpacingHint() {
-
-    return 74;
-  }
-
-  @Override
-  public int getYAxisTickMarkSpacingHint() {
-
-    return 44;
-  }
-
   // Chart Plot Area ///////////////////////////////
-
-  @Override
-  public boolean isPlotGridLinesVisible() {
-
-    return true;
-  }
-
-  @Override
-  public boolean isPlotGridVerticalLinesVisible() {
-
-    return true;
-  }
-
-  @Override
-  public boolean isPlotGridHorizontalLinesVisible() {
-
-    return true;
-  }
-
-  @Override
-  public Color getPlotBackgroundColor() {
-
-    return ChartColor.getAWTColor(ChartColor.WHITE);
-  }
 
   @Override
   public Color getPlotBorderColor() {
 
     return ChartColor.getAWTColor(ChartColor.BLACK);
-  }
-
-  @Override
-  public boolean isPlotBorderVisible() {
-
-    return true;
-  }
-
-  @Override
-  public boolean isPlotTicksMarksVisible() {
-
-    return true;
   }
 
   @Override
@@ -315,50 +130,14 @@ public class MatlabTheme implements Theme {
   }
 
   @Override
-  public double getPlotContentSize() {
+  public int getPlotMargin() {
 
-    return .92;
+    return 3;
   }
 
   // Category Charts ///////////////////////////////
 
-  @Override
-  public double getAvailableSpaceFill() {
-
-    return 0.9;
-  }
-
-  @Override
-  public boolean isOverlapped() {
-
-    return false;
-  }
-
   // Pie Charts ///////////////////////////////
-
-  @Override
-  public boolean isCircular() {
-
-    return true;
-  }
-
-  @Override
-  public double getStartAngleInDegrees() {
-
-    return 0;
-  }
-
-  @Override
-  public Font getPieFont() {
-
-    return new Font(Font.SANS_SERIF, Font.PLAIN, 15);
-  }
-
-  @Override
-  public double getAnnotationDistance() {
-
-    return .67;
-  }
 
   @Override
   public AnnotationType getAnnotationType() {
@@ -366,37 +145,7 @@ public class MatlabTheme implements Theme {
     return AnnotationType.Label;
   }
 
-  @Override
-  public boolean isDrawAllAnnotations() {
-
-    return false;
-  }
-
-  @Override
-  public double getDonutThickness() {
-
-    return .33;
-  }
-
-  @Override
-  public boolean isSumVisible() {
-
-  	return false;
-  }
-
-  @Override
-  public Font getSumFont() {
-
-    return new Font(Font.SANS_SERIF, Font.PLAIN, 12);
-  }
-
   // Line, Scatter, Area Charts ///////////////////////////////
-
-  @Override
-  public int getMarkerSize() {
-
-    return 8;
-  }
 
   @Override
   public boolean showMarkers() {
@@ -406,23 +155,6 @@ public class MatlabTheme implements Theme {
 
   // Error Bars ///////////////////////////////
 
-  @Override
-  public Color getErrorBarsColor() {
-
-    return ChartColor.getAWTColor(ChartColor.BLACK);
-  }
-
-  @Override
-  public boolean isErrorBarsColorSeriesColor() {
-
-    return false;
-  }
-
   // Annotations ///////////////////////////////
 
-  @Override
-  public Font getAnnotationFont() {
-
-    return new Font(Font.SANS_SERIF, Font.PLAIN, 12);
-  }
 }

--- a/xchart/src/main/java/org/knowm/xchart/style/MatlabTheme.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/MatlabTheme.java
@@ -378,6 +378,18 @@ public class MatlabTheme implements Theme {
     return .33;
   }
 
+  @Override
+  public boolean isSumVisible() {
+
+  	return false;
+  }
+
+  @Override
+  public Font getSumFont() {
+
+    return new Font(Font.SANS_SERIF, Font.PLAIN, 12);
+  }
+
   // Line, Scatter, Area Charts ///////////////////////////////
 
   @Override

--- a/xchart/src/main/java/org/knowm/xchart/style/PieStyler.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/PieStyler.java
@@ -16,6 +16,8 @@
  */
 package org.knowm.xchart.style;
 
+import java.awt.Font;
+
 import org.knowm.xchart.PieSeries.PieSeriesRenderStyle;
 
 /**
@@ -36,6 +38,9 @@ public class PieStyler extends Styler {
   private AnnotationType annotationType;
   private boolean drawAllAnnotations;
   private double donutThickness;
+
+  private boolean isSumVisible;
+  private Font sumFont;
 
   /**
    * Constructor
@@ -58,6 +63,9 @@ public class PieStyler extends Styler {
 
     // Annotations ////////////////////////////////
     this.hasAnnotations = true;
+
+    this.isSumVisible = theme.isSumVisible();
+    this.sumFont = theme.getSumFont();
   }
 
   public PieSeriesRenderStyle getDefaultSeriesRenderStyle() {
@@ -171,6 +179,38 @@ public class PieStyler extends Styler {
   public void setDonutThickness(double donutThickness) {
 
     this.donutThickness = donutThickness;
+  }
+
+  public boolean isSumVisible() {
+
+    return isSumVisible;
+  }
+
+  /**
+   * Sets whether or not the sum is visible in the centre of the pie chart.
+   *
+   * @param isSumVisible
+   */
+  public PieStyler setSumVisible(boolean isSumVisible) {
+
+    this.isSumVisible = isSumVisible;
+    return this;
+  }
+
+  public Font getSumFont() {
+
+    return sumFont;
+  }
+
+  /**
+   * Sets the font for the sum.
+   *
+   * @param isSumVisible
+   */
+  public PieStyler setSumFont(Font sumFont) {
+
+    this.sumFont = sumFont;
+    return this;
   }
 
   /**

--- a/xchart/src/main/java/org/knowm/xchart/style/PieStyler.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/PieStyler.java
@@ -205,11 +205,22 @@ public class PieStyler extends Styler {
   /**
    * Sets the font for the sum.
    *
-   * @param isSumVisible
+   * @param sumFont font
    */
   public PieStyler setSumFont(Font sumFont) {
 
     this.sumFont = sumFont;
+    return this;
+  }
+
+  /**
+   * Sets the font size for the sum.
+   *
+   * @param isSumVisible
+   */
+  public PieStyler setSumFontSize(float sumFontSize) {
+
+    this.sumFont = this.sumFont.deriveFont(sumFontSize);
     return this;
   }
 

--- a/xchart/src/main/java/org/knowm/xchart/style/Styler.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/Styler.java
@@ -65,6 +65,7 @@ public abstract class Styler {
   protected Theme theme = new XChartTheme();
 
   // Chart Style ///////////////////////////////
+  private Font baseFont;
   private Color chartBackgroundColor;
   private Color chartFontColor;
   private int chartPadding;
@@ -104,6 +105,8 @@ public abstract class Styler {
   protected void setAllStyles() {
 
     // Chart Style ///////////////////////////////
+	baseFont = theme.getBaseFont();
+
     chartBackgroundColor = theme.getChartBackgroundColor();
     chartFontColor = theme.getChartFontColor();
 
@@ -143,6 +146,23 @@ public abstract class Styler {
   }
 
   // Chart Style ///////////////////////////////
+
+  /**
+   * Set the base font
+   *
+   * @param baseFont
+   * @return styler
+   */
+  public Styler setBaseFont(Font baseFont) {
+
+    this.baseFont = baseFont;
+    return this;
+  }
+
+  public Font getBaseFont() {
+
+    return baseFont;
+  }
 
   /**
    * Set the chart background color - the part around the edge of the chart

--- a/xchart/src/main/java/org/knowm/xchart/style/Theme.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/Theme.java
@@ -33,6 +33,13 @@ public interface Theme extends SeriesMarkers, SeriesLines, SeriesColors {
 
   // Chart Style ///////////////////////////////
 
+  /**
+   * Base font, from which all other fonts are derived, if not set directly.
+   *
+   * @return base font
+   */
+  Font getBaseFont();
+
   Color getChartBackgroundColor();
 
   Color getChartFontColor();

--- a/xchart/src/main/java/org/knowm/xchart/style/Theme.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/Theme.java
@@ -149,6 +149,10 @@ public interface Theme extends SeriesMarkers, SeriesLines, SeriesColors {
 
   double getDonutThickness();
 
+  boolean isSumVisible();
+
+  Font getSumFont();
+
   // Line, Scatter, Area Charts ///////////////////////////////
 
   int getMarkerSize();

--- a/xchart/src/main/java/org/knowm/xchart/style/XChartTheme.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/XChartTheme.java
@@ -18,11 +18,7 @@ package org.knowm.xchart.style;
 
 import java.awt.BasicStroke;
 import java.awt.Color;
-import java.awt.Font;
-import java.awt.Stroke;
 
-import org.knowm.xchart.style.PieStyler.AnnotationType;
-import org.knowm.xchart.style.Styler.LegendPosition;
 import org.knowm.xchart.style.colors.ChartColor;
 import org.knowm.xchart.style.colors.XChartSeriesColors;
 import org.knowm.xchart.style.lines.XChartSeriesLines;
@@ -32,7 +28,7 @@ import org.knowm.xchart.style.markers.XChartSeriesMarkers;
 /**
  * @author timmolter
  */
-public class XChartTheme implements Theme {
+public class XChartTheme extends AbstractBaseTheme {
 
   // Chart Style ///////////////////////////////
 
@@ -42,17 +38,7 @@ public class XChartTheme implements Theme {
     return ChartColor.getAWTColor(ChartColor.GREY);
   }
 
-  @Override
-  public Color getChartFontColor() {
-
-    return ChartColor.getAWTColor(ChartColor.BLACK);
-  }
-
-  @Override
-  public int getChartPadding() {
-
-    return 10;
-  }
+  // SeriesMarkers, SeriesLines, SeriesColors ///////////////////////////////
 
   @Override
   public Color[] getSeriesColors() {
@@ -75,18 +61,6 @@ public class XChartTheme implements Theme {
   // Chart Title ///////////////////////////////
 
   @Override
-  public Font getChartTitleFont() {
-
-    return new Font(Font.SANS_SERIF, Font.BOLD, 14);
-  }
-
-  @Override
-  public boolean isChartTitleVisible() {
-
-    return true;
-  }
-
-  @Override
   public boolean isChartTitleBoxVisible() {
 
     return false;
@@ -104,197 +78,11 @@ public class XChartTheme implements Theme {
     return ChartColor.getAWTColor(ChartColor.GREY);
   }
 
-  @Override
-  public int getChartTitlePadding() {
-
-    return 5;
-  }
-
   // Chart Legend ///////////////////////////////
-
-  @Override
-  public Font getLegendFont() {
-
-    return new Font(Font.SANS_SERIF, Font.PLAIN, 11);
-  }
-
-  @Override
-  public boolean isLegendVisible() {
-
-    return true;
-  }
-
-  @Override
-  public Color getLegendBackgroundColor() {
-
-    return ChartColor.getAWTColor(ChartColor.WHITE);
-  }
-
-  @Override
-  public Color getLegendBorderColor() {
-
-    return ChartColor.getAWTColor(ChartColor.DARK_GREY);
-  }
-
-  @Override
-  public int getLegendPadding() {
-
-    return 10;
-  }
-
-  @Override
-  public int getLegendSeriesLineLength() {
-
-    return 24;
-  }
-
-  @Override
-  public LegendPosition getLegendPosition() {
-
-    return LegendPosition.OutsideE;
-  }
 
   // Chart Axes ///////////////////////////////
 
-  @Override
-  public boolean isXAxisTitleVisible() {
-
-    return true;
-  }
-
-  @Override
-  public boolean isYAxisTitleVisible() {
-
-    return true;
-  }
-
-  @Override
-  public Font getAxisTitleFont() {
-
-    return new Font(Font.SANS_SERIF, Font.BOLD, 12);
-  }
-
-  @Override
-  public boolean isXAxisTicksVisible() {
-
-    return true;
-  }
-
-  @Override
-  public boolean isYAxisTicksVisible() {
-
-    return true;
-  }
-
-  @Override
-  public Font getAxisTickLabelsFont() {
-
-    return new Font(Font.SANS_SERIF, Font.BOLD, 12);
-  }
-
-  @Override
-  public int getAxisTickMarkLength() {
-
-    return 3;
-  }
-
-  @Override
-  public int getAxisTickPadding() {
-
-    return 4;
-  }
-
-  @Override
-  public int getPlotMargin() {
-
-    return 4;
-  }
-
-  @Override
-  public Color getAxisTickMarksColor() {
-
-    return ChartColor.getAWTColor(ChartColor.DARK_GREY);
-  }
-
-  @Override
-  public Stroke getAxisTickMarksStroke() {
-
-    return new BasicStroke(1.0f);
-  }
-
-  @Override
-  public Color getAxisTickLabelsColor() {
-
-    return ChartColor.getAWTColor(ChartColor.BLACK);
-  }
-
-  @Override
-  public boolean isAxisTicksLineVisible() {
-
-    return true;
-  }
-
-  @Override
-  public boolean isAxisTicksMarksVisible() {
-
-    return true;
-  }
-
-  @Override
-  public int getAxisTitlePadding() {
-
-    return 10;
-  }
-
-  @Override
-  public int getXAxisTickMarkSpacingHint() {
-
-    return 74;
-  }
-
-  @Override
-  public int getYAxisTickMarkSpacingHint() {
-
-    return 44;
-  }
-
   // Chart Plot Area ///////////////////////////////
-
-  @Override
-  public boolean isPlotGridLinesVisible() {
-
-    return true;
-  }
-
-  @Override
-  public boolean isPlotGridVerticalLinesVisible() {
-
-    return true;
-  }
-
-  @Override
-  public boolean isPlotGridHorizontalLinesVisible() {
-
-    return true;
-  }
-
-  @Override
-  public Color getPlotBackgroundColor() {
-
-    return ChartColor.getAWTColor(ChartColor.WHITE);
-  }
-
-  @Override
-  public Color getPlotBorderColor() {
-
-    return ChartColor.getAWTColor(ChartColor.DARK_GREY);
-  }
-
-  @Override
-  public boolean isPlotBorderVisible() {
-
-    return true;
-  }
 
   @Override
   public boolean isPlotTicksMarksVisible() {
@@ -302,127 +90,14 @@ public class XChartTheme implements Theme {
     return false;
   }
 
-  @Override
-  public Color getPlotGridLinesColor() {
-
-    return ChartColor.getAWTColor(ChartColor.GREY);
-  }
-
-  @Override
-  public Stroke getPlotGridLinesStroke() {
-
-    return new BasicStroke(1.0f, BasicStroke.CAP_BUTT, BasicStroke.JOIN_BEVEL, 10.0f, new float[]{3.0f, 5.0f}, 0.0f);
-  }
-
-  @Override
-  public double getPlotContentSize() {
-
-    return .92;
-  }
-
   // Category Charts ///////////////////////////////
-
-  @Override
-  public double getAvailableSpaceFill() {
-
-    return 0.9;
-  }
-
-  @Override
-  public boolean isOverlapped() {
-
-    return false;
-  }
 
   // Pie Charts ///////////////////////////////
 
-  @Override
-  public boolean isCircular() {
-
-    return true;
-  }
-
-  @Override
-  public double getStartAngleInDegrees() {
-
-    return 0;
-  }
-
-  @Override
-  public Font getPieFont() {
-
-    return new Font(Font.SANS_SERIF, Font.PLAIN, 15);
-  }
-
-  @Override
-  public double getAnnotationDistance() {
-
-    return .67;
-  }
-
-  @Override
-  public AnnotationType getAnnotationType() {
-
-    return AnnotationType.Percentage;
-  }
-
-  @Override
-  public boolean isDrawAllAnnotations() {
-
-    return false;
-  }
-
-  @Override
-  public double getDonutThickness() {
-
-    return .33;
-  }
-
-  @Override
-  public boolean isSumVisible() {
-
-  	return false;
-  }
-
-  @Override
-  public Font getSumFont() {
-
-    return new Font(Font.SANS_SERIF, Font.PLAIN, 12);
-  }
-
   // Line, Scatter, Area Charts ///////////////////////////////
-
-  @Override
-  public int getMarkerSize() {
-
-    return 8;
-  }
-
-  @Override
-  public boolean showMarkers() {
-
-    return true;
-  }
 
   // Error Bars ///////////////////////////////
 
-  @Override
-  public Color getErrorBarsColor() {
-
-    return ChartColor.getAWTColor(ChartColor.BLACK);
-  }
-
-  @Override
-  public boolean isErrorBarsColorSeriesColor() {
-
-    return false;
-  }
-
   // Annotations ///////////////////////////////
 
-  @Override
-  public Font getAnnotationFont() {
-
-    return new Font(Font.SANS_SERIF, Font.PLAIN, 12);
-  }
 }

--- a/xchart/src/main/java/org/knowm/xchart/style/XChartTheme.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/XChartTheme.java
@@ -378,6 +378,18 @@ public class XChartTheme implements Theme {
     return .33;
   }
 
+  @Override
+  public boolean isSumVisible() {
+
+  	return false;
+  }
+
+  @Override
+  public Font getSumFont() {
+
+    return new Font(Font.SANS_SERIF, Font.PLAIN, 12);
+  }
+
   // Line, Scatter, Area Charts ///////////////////////////////
 
   @Override

--- a/xchart/src/main/java/org/knowm/xchart/style/colors/BaseSeriesColors.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/colors/BaseSeriesColors.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright 2015-2017 Knowm Inc. (http://knowm.org) and contributors.
+ * Copyright 2011-2015 Xeiam LLC (http://xeiam.com) and contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.knowm.xchart.style.colors;
+
+import java.awt.Color;
+
+/**
+ * Colors are taken from http://colorbrewer2.org/#type=qualitative&scheme=Set3&n=12.
+ *
+ * @author timmolter
+ * @author ekleinod
+ */
+public class BaseSeriesColors implements SeriesColors {
+
+  private final Color[] seriesColors;
+
+  /**
+   * Constructor.
+   */
+  public BaseSeriesColors() {
+
+    seriesColors = new Color[]{
+    		new Color(141,211,199),
+    		new Color(255,255,179),
+    		new Color(190,186,218),
+    		new Color(251,128,114),
+    		new Color(128,177,211),
+    		new Color(253,180,98),
+    		new Color(179,222,105),
+    		new Color(252,205,229),
+    		new Color(217,217,217),
+    		new Color(188,128,189),
+    		new Color(204,235,197),
+    		new Color(255,237,111)
+    };
+
+  }
+
+  @Override
+  public Color[] getSeriesColors() {
+
+    return seriesColors;
+  }
+}

--- a/xchart/src/main/java/org/knowm/xchart/style/lines/BaseSeriesLines.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/lines/BaseSeriesLines.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2015-2017 Knowm Inc. (http://knowm.org) and contributors.
+ * Copyright 2011-2015 Xeiam LLC (http://xeiam.com) and contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.knowm.xchart.style.lines;
+
+import java.awt.BasicStroke;
+
+/**
+ * @author timmolter
+ * @author ekleinod
+ */
+public class BaseSeriesLines implements SeriesLines {
+
+  private final BasicStroke[] seriesLines;
+
+  /**
+   * Constructor
+   */
+  public BaseSeriesLines() {
+
+    seriesLines = new BasicStroke[]{SOLID, DOT_DOT, DASH_DASH, DASH_DOT};
+  }
+
+  @Override
+  public BasicStroke[] getSeriesLines() {
+
+    return seriesLines;
+  }
+}

--- a/xchart/src/main/java/org/knowm/xchart/style/markers/BaseSeriesMarkers.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/markers/BaseSeriesMarkers.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2015-2017 Knowm Inc. (http://knowm.org) and contributors.
+ * Copyright 2011-2015 Xeiam LLC (http://xeiam.com) and contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.knowm.xchart.style.markers;
+
+/**
+ * @author timmolter
+ * @author ekleinod
+ */
+public class BaseSeriesMarkers implements SeriesMarkers {
+
+  private final Marker[] seriesMarkers;
+
+  /**
+   * Constructor
+   */
+  public BaseSeriesMarkers() {
+
+    seriesMarkers = new Marker[]{CIRCLE, SQUARE, DIAMOND, TRIANGLE_UP, TRIANGLE_DOWN};
+  }
+
+  @Override
+  public Marker[] getSeriesMarkers() {
+
+    return seriesMarkers;
+  }
+}

--- a/xchart/src/test/java/org/knowm/xchart/VectorGraphicsEncoderTest.java
+++ b/xchart/src/test/java/org/knowm/xchart/VectorGraphicsEncoderTest.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2015-2017 Knowm Inc. (http://knowm.org) and contributors.
+ * Copyright 2011-2015 Xeiam LLC (http://xeiam.com) and contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.knowm.xchart;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.knowm.xchart.VectorGraphicsEncoder.VectorGraphicsFormat;
+
+/**
+ * @author ekleinod
+ */
+public class VectorGraphicsEncoderTest {
+
+	@Test
+	public void testAddFileExtension() {
+
+		for (VectorGraphicsFormat format : VectorGraphicsFormat.values()) {
+
+			// test -> test.svg
+			Assert.assertEquals(String.format("test.%s", format.toString().toLowerCase()), VectorGraphicsEncoder.addFileExtension("test", format));
+
+			// test.svg -> test.svg
+			Assert.assertEquals(String.format("test.%s", format.toString().toLowerCase()), VectorGraphicsEncoder.addFileExtension(String.format("test.%s", format.toString().toLowerCase()), format));
+
+			// test.svgsvg -> test.svgsvg.svg
+			Assert.assertEquals(String.format("test.%1$s%1$s.%1$s", format.toString().toLowerCase()), VectorGraphicsEncoder.addFileExtension(String.format("test.%1$s%1$s", format.toString().toLowerCase()), format));
+
+			// test.svg.svg -> test.svg.svg
+			Assert.assertEquals(String.format("test.%1$s.%1$s", format.toString().toLowerCase()), VectorGraphicsEncoder.addFileExtension(String.format("test.%1$s.%1$s", format.toString().toLowerCase()), format));
+
+			// test.txt -> test.txt.svg
+			Assert.assertEquals(String.format("test.txt.%1$s", format.toString().toLowerCase()), VectorGraphicsEncoder.addFileExtension("test.txt", format));
+
+		}
+
+	}
+
+}


### PR DESCRIPTION
I implemented my feature request for an optional sum (total value) in pie charts (issue #174)

Additionally I included the test class for VectorGraphicsEncoder, I did not know how to exclude the specific commit.