### PR TITLE
Added default yAxis title.

### DIFF
--- a/xchart/src/main/java/org/knowm/xchart/BubbleChart.java
+++ b/xchart/src/main/java/org/knowm/xchart/BubbleChart.java
@@ -88,7 +88,7 @@ public class BubbleChart extends Chart<BubbleStyler, BubbleSeries> {
     this(chartBuilder.width, chartBuilder.height, chartBuilder.chartTheme);
     setTitle(chartBuilder.title);
     setXAxisTitle(chartBuilder.xAxisTitle);
-    setYAxisGroupTitle(0, chartBuilder.yAxisTitle);
+    setYAxisTitle(chartBuilder.yAxisTitle);
   }
 
   /**

--- a/xchart/src/main/java/org/knowm/xchart/CategoryChart.java
+++ b/xchart/src/main/java/org/knowm/xchart/CategoryChart.java
@@ -86,7 +86,7 @@ public class CategoryChart extends Chart<CategoryStyler, CategorySeries> {
     this(chartBuilder.width, chartBuilder.height, chartBuilder.chartTheme);
     setTitle(chartBuilder.title);
     setXAxisTitle(chartBuilder.xAxisTitle);
-    setYAxisGroupTitle(0, chartBuilder.yAxisTitle);
+    setYAxisTitle(chartBuilder.yAxisTitle);
   }
 
   /**

--- a/xchart/src/main/java/org/knowm/xchart/QuickChart.java
+++ b/xchart/src/main/java/org/knowm/xchart/QuickChart.java
@@ -77,7 +77,7 @@ public final class QuickChart {
     // Customize Chart
     chart.setTitle(chartTitle);
     chart.setXAxisTitle(xTitle);
-    chart.setYAxisGroupTitle(0, yTitle);
+    chart.setYAxisTitle(yTitle);
 
     // Series
     for (int i = 0; i < yData.length; i++) {
@@ -112,7 +112,7 @@ public final class QuickChart {
     // Customize Chart
     chart.setTitle(chartTitle);
     chart.setXAxisTitle(xTitle);
-    chart.setYAxisGroupTitle(0, yTitle);
+    chart.setYAxisTitle(yTitle);
 
     XYSeries series = chart.addSeries(seriesName, xData, yData);
     series.setMarker(SeriesMarkers.NONE);

--- a/xchart/src/main/java/org/knowm/xchart/XYChart.java
+++ b/xchart/src/main/java/org/knowm/xchart/XYChart.java
@@ -88,7 +88,7 @@ public class XYChart extends Chart<XYStyler, XYSeries> {
     this(chartBuilder.width, chartBuilder.height, chartBuilder.chartTheme);
     setTitle(chartBuilder.title);
     setXAxisTitle(chartBuilder.xAxisTitle);
-    setYAxisGroupTitle(0, chartBuilder.yAxisTitle);
+    setYAxisTitle(chartBuilder.yAxisTitle);
   }
 
   /**

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Chart.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Chart.java
@@ -46,6 +46,7 @@ public abstract class Chart<ST extends Styler, S extends Series> {
   private int height;
   private String title = "";
   private String xAxisTitle = "";
+  private String yAxisTitle = "";
   private HashMap<Integer, String> yAxisGroupTitleMap = new HashMap<Integer, String>();
 
   /**
@@ -149,9 +150,23 @@ public abstract class Chart<ST extends Styler, S extends Series> {
     this.xAxisTitle = xAxisTitle;
   }
 
+  public String getYAxisTitle() {
+
+    return yAxisTitle;
+  }
+  
+  public void setYAxisTitle(String yAxisTitle) {
+
+    this.yAxisTitle = yAxisTitle;
+  }
+  
   public String getYAxisGroupTitle(int yAxisGroup) {
 
-    return yAxisGroupTitleMap.get(yAxisGroup);
+    String title = yAxisGroupTitleMap.get(yAxisGroup);
+    if (title == null) {
+      return yAxisTitle;
+    }
+    return title;
   }
 
   public void setYAxisGroupTitle(int yAxisGroup, String yAxisTitle) {


### PR DESCRIPTION
Continuing issue #54, pull request #184  
> I think the yAxisTitle should be set to the given chart yAxis title for all groups be default. So in this case Y as a yAxis title should show up on both sides.

I added yAxisTitle property. This is the default title for all groups by default. 
To hide this title on group 1 call `chart.setYAxisGroupTitle(1, "");`

