### PR TITLE
Added vertical alignment support for X axis labels

### DIFF
--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxisTickLabels.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxisTickLabels.java
@@ -190,13 +190,13 @@ public class AxisTickLabels<ST extends AxesChartStyler, S extends Series> implem
           int tickLabelY = tickLabelBounds.getBounds().height;
           int yAlignmentOffset;
           switch (styler.getxAxisLabelAlignmentVertical()) {
-            case Left:
+            case Right:
               yAlignmentOffset = maxTickLabelY - tickLabelY;
               break;
             case Centre:
               yAlignmentOffset = (maxTickLabelY - tickLabelY) / 2;
               break;
-            case Right:
+            case Left:
             default:
               yAlignmentOffset = 0;
           }

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxisTickLabels.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxisTickLabels.java
@@ -139,6 +139,33 @@ public class AxisTickLabels<ST extends AxesChartStyler, S extends Series> implem
       double yOffset = chart.getXAxis().getAxisTitle().getBounds().getY();
       double width = chart.getXAxis().getBounds().getWidth();
       double maxTickLabelHeight = 0;
+      
+      int maxTickLabelY = 0;
+      for (int i = 0; i < chart.getXAxis().getAxisTickCalculator().getTickLabels().size(); i++) {
+
+        String tickLabel = chart.getXAxis().getAxisTickCalculator().getTickLabels().get(i);
+        // System.out.println("tickLabel: " + tickLabel);
+        double tickLocation = chart.getXAxis().getAxisTickCalculator().getTickLocations().get(i);
+        double shiftedTickLocation = xOffset + tickLocation;
+
+        // discard null and out of bounds labels
+        if (tickLabel != null && shiftedTickLocation > xOffset && shiftedTickLocation < xOffset + width) {
+          // some are null for logarithmic axes
+
+          FontRenderContext frc = g.getFontRenderContext();
+          TextLayout textLayout = new TextLayout(tickLabel, styler.getAxisTickLabelsFont(), frc);
+          // System.out.println(textLayout.getOutline(null).getBounds().toString());
+
+          // Shape shape = v.getOutline();
+          AffineTransform rot = AffineTransform.getRotateInstance(-1 * Math.toRadians(styler.getXAxisLabelRotation()),
+              0, 0);
+          Shape shape = textLayout.getOutline(rot);
+          Rectangle2D tickLabelBounds = shape.getBounds2D();
+          if (tickLabelBounds.getBounds().height > maxTickLabelY) {
+            maxTickLabelY = tickLabelBounds.getBounds().height;
+          }
+        }
+      }
 
       // System.out.println("axisTick.getTickLabels().size(): " + axisTick.getTickLabels().size());
       for (int i = 0; i < chart.getXAxis().getAxisTickCalculator().getTickLabels().size(); i++) {
@@ -159,6 +186,20 @@ public class AxisTickLabels<ST extends AxesChartStyler, S extends Series> implem
           AffineTransform rot = AffineTransform.getRotateInstance(-1 * Math.toRadians(styler.getXAxisLabelRotation()), 0, 0);
           Shape shape = textLayout.getOutline(rot);
           Rectangle2D tickLabelBounds = shape.getBounds2D();
+          
+          int tickLabelY = tickLabelBounds.getBounds().height;
+          int yAlignmentOffset;
+          switch (styler.getxAxisLabelAlignmentVertical()) {
+            case Left:
+              yAlignmentOffset = maxTickLabelY - tickLabelY;
+              break;
+            case Centre:
+              yAlignmentOffset = (maxTickLabelY - tickLabelY) / 2;
+              break;
+            case Right:
+            default:
+              yAlignmentOffset = 0;
+          }
 
           AffineTransform orig = g.getTransform();
           AffineTransform at = new AffineTransform();
@@ -176,7 +217,7 @@ public class AxisTickLabels<ST extends AxesChartStyler, S extends Series> implem
           }
           // System.out.println("tickLabelBounds: " + tickLabelBounds.toString());
           double shiftX = -1 * tickLabelBounds.getX() * Math.sin(Math.toRadians(styler.getXAxisLabelRotation()));
-          double shiftY = -1 * (tickLabelBounds.getY() + tickLabelBounds.getHeight());
+          double shiftY = -1 * (tickLabelBounds.getY() + tickLabelBounds.getHeight() + yAlignmentOffset);
           // System.out.println(shiftX);
           // System.out.println("shiftY: " + shiftY);
           at.translate(xPos + shiftX, yOffset + shiftY);

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxisTickLabels.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxisTickLabels.java
@@ -189,7 +189,7 @@ public class AxisTickLabels<ST extends AxesChartStyler, S extends Series> implem
           
           int tickLabelY = tickLabelBounds.getBounds().height;
           int yAlignmentOffset;
-          switch (styler.getxAxisLabelAlignmentVertical()) {
+          switch (styler.getXAxisLabelAlignmentVertical()) {
             case Right:
               yAlignmentOffset = maxTickLabelY - tickLabelY;
               break;

--- a/xchart/src/main/java/org/knowm/xchart/style/AxesChartStyler.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/AxesChartStyler.java
@@ -771,11 +771,11 @@ public abstract class AxesChartStyler extends Styler {
     return this;
   }
 
-  public TextAlignment getxAxisLabelAlignmentVertical() {
+  public TextAlignment getXAxisLabelAlignmentVertical() {
     return xAxisLabelAlignmentVertical;
   }
 
-  public void setxAxisLabelAlignmentVertical(TextAlignment xAxisLabelAlignmentVertical) {
+  public void setXAxisLabelAlignmentVertical(TextAlignment xAxisLabelAlignmentVertical) {
     this.xAxisLabelAlignmentVertical = xAxisLabelAlignmentVertical;
   }
 }

--- a/xchart/src/main/java/org/knowm/xchart/style/AxesChartStyler.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/AxesChartStyler.java
@@ -52,6 +52,7 @@ public abstract class AxesChartStyler extends Styler {
   private Double yAxisMin;
   private Double yAxisMax;
   private TextAlignment xAxisLabelAlignment = TextAlignment.Centre;
+  private TextAlignment xAxisLabelAlignmentVertical = TextAlignment.Centre;
   private TextAlignment yAxisLabelAlignment = TextAlignment.Left;
   private int xAxisLabelRotation = 0;
 
@@ -768,5 +769,13 @@ public abstract class AxesChartStyler extends Styler {
 
     this.yAxisDecimalPattern = yAxisDecimalPattern;
     return this;
+  }
+
+  public TextAlignment getxAxisLabelAlignmentVertical() {
+    return xAxisLabelAlignmentVertical;
+  }
+
+  public void setxAxisLabelAlignmentVertical(TextAlignment xAxisLabelAlignmentVertical) {
+    this.xAxisLabelAlignmentVertical = xAxisLabelAlignmentVertical;
   }
 }


### PR DESCRIPTION
Added vertical alignment support for X axis labels (useful with 45/90/270 degrees rotation etc).

Examples:
<img width="1552" alt="screen shot 2017-06-16 at 03 30 10" src="https://user-images.githubusercontent.com/1076779/27207111-ccebcf3e-5244-11e7-88d3-46bca35fbf5c.png">
<img width="1552" alt="screen shot 2017-06-16 at 03 30 16" src="https://user-images.githubusercontent.com/1076779/27207115-d2e296c0-5244-11e7-81cc-bc6cf54dd122.png">
<img width="1552" alt="screen shot 2017-06-16 at 03 30 19" src="https://user-images.githubusercontent.com/1076779/27207110-cceb069e-5244-11e7-8e93-798071a9c837.png">
