### PR TITLE
Fixed painting area in wrong color when plotting area charts

### DIFF
--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Category_Line_Area_Scatter.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Category_Line_Area_Scatter.java
@@ -190,7 +190,6 @@ public class PlotContent_Category_Line_Area_Scatter<ST extends Styler, S extends
 
             double yBottomOfArea = getBounds().getY() + getBounds().getHeight() - yTopMargin;
 
-            g.setColor(series.getLineColor());
             g.setStroke(series.getLineStyle());
             Shape line = new Line2D.Double(xOffset, yBottomOfArea, xOffset, yOffset);
             g.draw(line);
@@ -255,6 +254,7 @@ public class PlotContent_Category_Line_Area_Scatter<ST extends Styler, S extends
       }
 
       // close any open path for area charts
+      g.setColor(series.getFillColor());
       closePath(g, path, previousX, getBounds(), yTopMargin);
     }
   }

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_XY.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_XY.java
@@ -183,7 +183,6 @@ public class PlotContent_XY<ST extends AxesChartStyler, S extends Series> extend
 
           if (previousX != -Double.MAX_VALUE && previousY != -Double.MAX_VALUE) {
 
-            g.setColor(series.getFillColor());
             double yBottomOfArea = getBounds().getY() + getBounds().getHeight() - yTopMargin;
 
             if (path == null) {
@@ -259,6 +258,7 @@ public class PlotContent_XY<ST extends AxesChartStyler, S extends Series> extend
       }
 
       // close any open path for area charts
+      g.setColor(series.getFillColor());
       closePath(g, path, previousX, getBounds(), yTopMargin);
     }
   }


### PR DESCRIPTION
Fixed the problem where the area in the area chart is painted using the default set of colors instead of those provided by user.

Consider following example:
```java
XYChart chartSavings = /* new instance of XYChart here */ ;

XYSeries chartSeries1 = chartSavings.addSeries("Series 1", x1values, y1values);
chartSeries1.setMarker(SeriesMarkers.NONE);
chartSeries1.setFillColor(new Color(127, 127, 127));
chartSeries1.setLineColor(new Color(127, 127, 127));

XYSeries chartSeries2 = chartSavings.addSeries("Series 2", x2values, y2values);
chartSeries2.setMarker(SeriesMarkers.NONE);
chartSeries2.setFillColor(new Color(255, 102, 0));
chartSeries2.setLineColor(new Color(255, 102, 0));
```

The current result does not respect the colors, set using ``setFillColor()`` method and produces the result as follows:
![image](https://user-images.githubusercontent.com/8102102/27433622-c47653a4-5755-11e7-9762-081771574bae.png)


Instead, we want to have the whole space filled with custom color, which is the case when running the same example after the fix:
![image](https://user-images.githubusercontent.com/8102102/27433709-1a660c28-5756-11e7-8796-af78394929df.png)
