### PR TITLE
issue #201 - Add support for turning anti-aliasing off

### DIFF
--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Axis.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Axis.java
@@ -17,6 +17,7 @@
 package org.knowm.xchart.internal.chartpart;
 
 import java.awt.Graphics2D;
+import java.awt.RenderingHints;
 import java.awt.Shape;
 import java.awt.font.FontRenderContext;
 import java.awt.font.TextLayout;
@@ -249,6 +250,9 @@ public class Axis<ST extends AxesChartStyler, S extends Series> implements Chart
   @Override
   public void paint(Graphics2D g) {
 
+    Object oldHint = g.getRenderingHint(RenderingHints.KEY_ANTIALIASING);
+    g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+
     // determine Axis bounds
     if (direction == Direction.Y) { // Y-Axis - gets called first
 
@@ -284,6 +288,8 @@ public class Axis<ST extends AxesChartStyler, S extends Series> implements Chart
       axisTitle.paint(g);
       axisTick.paint(g);
     }
+
+    g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, oldHint);
   }
 
   /**

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Chart.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Chart.java
@@ -81,7 +81,7 @@ public abstract class Chart<ST extends Styler, S extends Series> {
   protected void paintBackground(Graphics2D g) {
 
     // paint chart main background
-    g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON); // global rendering hint
+    g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, styler.getAntiAlias() ? RenderingHints.VALUE_ANTIALIAS_ON : RenderingHints.VALUE_ANTIALIAS_OFF); // global rendering hint
     g.setColor(styler.getChartBackgroundColor());
     Shape rect = new Rectangle2D.Double(0, 0, getWidth(), getHeight());
     g.fill(rect);

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/ChartTitle.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/ChartTitle.java
@@ -18,6 +18,7 @@ package org.knowm.xchart.internal.chartpart;
 
 import java.awt.BasicStroke;
 import java.awt.Graphics2D;
+import java.awt.RenderingHints;
 import java.awt.Shape;
 import java.awt.font.FontRenderContext;
 import java.awt.font.TextLayout;
@@ -50,6 +51,9 @@ public class ChartTitle implements ChartPart {
     if (!chart.getStyler().isChartTitleVisible() || chart.getTitle().length() == 0) {
       return;
     }
+
+    Object oldHint = g.getRenderingHint(RenderingHints.KEY_ANTIALIASING);
+    g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
 
     // create rectangle first for sizing
     FontRenderContext frc = g.getFontRenderContext();
@@ -93,6 +97,7 @@ public class ChartTitle implements ChartPart {
     // g.setColor(Color.blue);
     // g.draw(bounds);
 
+    g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, oldHint);
   }
 
   /**

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Legend_Bubble.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Legend_Bubble.java
@@ -18,6 +18,7 @@ package org.knowm.xchart.internal.chartpart;
 
 import java.awt.Graphics2D;
 import java.awt.Shape;
+import java.awt.RenderingHints;
 import java.awt.geom.Ellipse2D;
 import java.awt.geom.Rectangle2D;
 import java.util.Map;
@@ -53,6 +54,9 @@ public class Legend_Bubble<ST extends AxesChartStyler, S extends Series> extends
     double startx = xOffset + chart.getStyler().getLegendPadding();
     double starty = yOffset + chart.getStyler().getLegendPadding();
 
+    Object oldHint = g.getRenderingHint(RenderingHints.KEY_ANTIALIASING);
+    g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+
     Map<String, NoMarkersSeries> map = chart.getSeriesMap();
     for (NoMarkersSeries series : map.values()) {
 
@@ -79,6 +83,7 @@ public class Legend_Bubble<ST extends AxesChartStyler, S extends Series> extends
       paintSeriesText(g, seriesTextBounds, BOX_SIZE, x, starty);
       starty += legendEntryHeight + chart.getStyler().getLegendPadding();
     }
+    g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, oldHint);
   }
 
   @Override

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Legend_Marker.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Legend_Marker.java
@@ -18,6 +18,7 @@ package org.knowm.xchart.internal.chartpart;
 
 import java.awt.BasicStroke;
 import java.awt.Graphics2D;
+import java.awt.RenderingHints;
 import java.awt.Shape;
 import java.awt.geom.Line2D;
 import java.awt.geom.Path2D;
@@ -57,6 +58,9 @@ public class Legend_Marker<ST extends AxesChartStyler, S extends Series> extends
     // Draw legend content inside legend box
     double startx = xOffset + chart.getStyler().getLegendPadding();
     double starty = yOffset + chart.getStyler().getLegendPadding();
+
+    Object oldHint = g.getRenderingHint(RenderingHints.KEY_ANTIALIASING);
+    g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
 
     Map<String, MarkersSeries> map = chart.getSeriesMap();
     for (MarkersSeries series : map.values()) {
@@ -140,6 +144,7 @@ public class Legend_Marker<ST extends AxesChartStyler, S extends Series> extends
       }
       starty += legendEntryHeight + chart.getStyler().getLegendPadding();
     }
+    g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, oldHint);
   }
 
   @Override

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Legend_Pie.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Legend_Pie.java
@@ -18,6 +18,7 @@ package org.knowm.xchart.internal.chartpart;
 
 import java.awt.Graphics2D;
 import java.awt.Shape;
+import java.awt.RenderingHints;
 import java.awt.geom.Rectangle2D;
 import java.util.Map;
 
@@ -48,6 +49,9 @@ public class Legend_Pie<ST extends AxesChartStyler, S extends Series> extends Le
     double startx = xOffset + chart.getStyler().getLegendPadding();
     double starty = yOffset + chart.getStyler().getLegendPadding();
 
+    Object oldHint = g.getRenderingHint(RenderingHints.KEY_ANTIALIASING);
+    g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+
     Map<String, Series> map = chart.getSeriesMap();
     for (Series series : map.values()) {
 
@@ -71,6 +75,8 @@ public class Legend_Pie<ST extends AxesChartStyler, S extends Series> extends Le
       paintSeriesText(g, seriesTextBounds, BOX_SIZE, x, starty);
       starty += legendEntryHeight + chart.getStyler().getLegendPadding();
     }
+
+    g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, oldHint);
   }
 
   @Override

--- a/xchart/src/main/java/org/knowm/xchart/style/Styler.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/Styler.java
@@ -118,6 +118,8 @@ public abstract class Styler {
   private Font annotationsFont;
   boolean hasAnnotations = false; // set by subclass
 
+  private boolean antiAlias = true;
+
   private String decimalPattern;
 
   private HashMap<Integer, YAxisPosition> yAxisAlignmentMap = new HashMap<Integer, YAxisPosition>();
@@ -699,5 +701,15 @@ public abstract class Styler {
   public Theme getTheme() {
 
     return theme;
+  }
+
+  public boolean getAntiAlias() {
+
+    return antiAlias;
+  }
+
+  public void setAntiAlias(boolean newVal) {
+
+    antiAlias = newVal;
   }
 }


### PR DESCRIPTION
Issue #201 - Add support for turning anti-aliasing off

Fonts, though, are rendered always by temporarily turning anti-aliasing on no
matter what the setting is.

This improves performance penalty in a real-life curve fitting application when
compared with JFreeChart from 3.9% penalty to 1.3% penalty.