### PR TITLE
Added radar chart

### DIFF
--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/radar/RadarChart01.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/radar/RadarChart01.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2015-2017 Knowm Inc. (http://knowm.org) and contributors.
+ * Copyright 2011-2015 Xeiam LLC (http://xeiam.com) and contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.knowm.xchart.demo.charts.radar;
+
+import org.knowm.xchart.RadarChart;
+import org.knowm.xchart.RadarChartBuilder;
+import org.knowm.xchart.SwingWrapper;
+import org.knowm.xchart.demo.charts.ExampleChart;
+
+/**
+ * Radar Chart GGPlot2 Theme
+ * <p>
+ * Demonstrates the following:
+ * <ul>
+ * <li>Radar Chart
+ * <li>RadarChartBuilder
+ * <li>Setting start angle
+ */
+public class RadarChart01 implements ExampleChart<RadarChart> {
+
+  public static void main(String[] args) {
+
+    ExampleChart<RadarChart> exampleChart = new RadarChart01();
+    RadarChart chart = exampleChart.getChart();
+    new SwingWrapper<RadarChart>(chart).displayChart();
+  }
+
+  @Override
+  public RadarChart getChart() {
+
+    // Create Chart
+    RadarChart chart = new RadarChartBuilder().width(800).height(600).title("Radar Chart").build();
+
+    // Series
+    chart.setVariableLabels(new String[] {"Sales", "Marketting", "Development", "Customer Support", "Information Technology", "Administration" });
+    chart.addSeries("Old System", new double[] { 0.78, 0.85, 0.80, 0.82, 0.93, 0.92 }, new String[] { "Lowest varible 78%", "85%", null, null, null, null });
+    chart.addSeries("New System", new double[] { 0.67, 0.73, 0.97, 0.95, 0.93, 0.73});
+    chart.addSeries("Experimental System", new double[] { 0.37, 0.93, 0.57, 0.55, 0.33, 0.73});
+    
+    return chart;
+  }
+}

--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue189_1.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue189_1.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright 2015-2017 Knowm Inc. (http://knowm.org) and contributors.
+ * Copyright 2011-2015 Xeiam LLC (http://xeiam.com) and contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.knowm.xchart.standalone.issues;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.knowm.xchart.RadarChart;
+import org.knowm.xchart.RadarChart.RadarRenderStyle;
+import org.knowm.xchart.SwingWrapper;
+import org.knowm.xchart.demo.charts.ExampleChart;
+import org.knowm.xchart.demo.charts.radar.RadarChart01;
+import org.knowm.xchart.style.lines.SeriesLines;
+
+/**
+ * Create a Chart matrix
+ *
+ * @author timmolter
+ */
+public class TestForIssue189_1 {
+
+  public static void main(String[] args) {
+
+    ExampleChart<RadarChart> alc = new RadarChart01();
+    List<RadarChart> charts = new ArrayList<RadarChart>();
+    {
+      RadarChart chart = alc.getChart();
+      chart.setTitle("Default radar chart");
+      charts.add(chart);
+    }
+    {
+      RadarChart chart = alc.getChart();
+      chart.setTitle("Radar chart with circle rendering");
+      chart.getStyler().setPlotGridLinesStroke(SeriesLines.NONE);
+      chart.setRadarRenderStyle(RadarRenderStyle.Circle);
+      charts.add(chart);
+    }
+    {
+      //current default
+      RadarChart chart = alc.getChart();
+      chart.setTitle("Radar chart with 3 variables and start angle");
+      chart.getStyler().setToolTipsEnabled(true);
+      chart.getStyler().setStartAngleInDegrees(45);
+      chart.getStyler().setPlotGridLinesStroke(SeriesLines.NONE);
+      chart.setVariableLabels(new String[] {"Sales", "Marketting", "Development"});
+      charts.add(chart);
+    }
+    {
+      RadarChart chart = alc.getChart();
+      chart.setTitle("Radar chart with non circular rendering");
+      chart.getStyler().setPlotGridLinesStroke(SeriesLines.NONE);
+      chart.getStyler().setCircular(false);      
+      charts.add(chart);
+    }
+
+    new SwingWrapper<RadarChart>(charts).displayChartMatrix();
+  }
+
+}

--- a/xchart/src/main/java/org/knowm/xchart/RadarChart.java
+++ b/xchart/src/main/java/org/knowm/xchart/RadarChart.java
@@ -1,0 +1,206 @@
+/**
+ * Copyright 2015-2017 Knowm Inc. (http://knowm.org) and contributors.
+ * Copyright 2011-2015 Xeiam LLC (http://xeiam.com) and contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.knowm.xchart;
+
+import java.awt.Graphics2D;
+
+import org.knowm.xchart.internal.chartpart.Chart;
+import org.knowm.xchart.internal.chartpart.Legend_Pie;
+import org.knowm.xchart.internal.chartpart.Plot_Radar;
+import org.knowm.xchart.internal.style.SeriesColorMarkerLineStyle;
+import org.knowm.xchart.internal.style.SeriesColorMarkerLineStyleCycler;
+import org.knowm.xchart.style.RadarStyler;
+import org.knowm.xchart.style.Styler.ChartTheme;
+import org.knowm.xchart.style.Theme;
+
+/**
+ * @author timmolter
+ */
+public class RadarChart extends Chart<RadarStyler, RadarSeries> {
+  public enum RadarRenderStyle  {
+    Polygon, Circle;
+  }
+  
+  private RadarRenderStyle radarRenderStyle = RadarRenderStyle.Polygon;
+
+  protected String[] variableLabels;
+  
+  /**
+   * Constructor - the default Chart Theme will be used (XChartTheme)
+   *
+   * @param width
+   * @param height
+   */
+  public RadarChart(int width, int height) {
+
+    super(width, height, new RadarStyler());
+    plot = new Plot_Radar(this);
+    legend = new Legend_Pie(this);
+  }
+
+  /**
+   * Constructor
+   *
+   * @param width
+   * @param height
+   * @param theme - pass in a instance of Theme class, probably a custom Theme.
+   */
+  public RadarChart(int width, int height, Theme theme) {
+
+    this(width, height);
+    styler.setTheme(theme);
+  }
+
+  /**
+   * Constructor
+   *
+   * @param width
+   * @param height
+   * @param chartTheme - pass in the desired ChartTheme enum
+   */
+  public RadarChart(int width, int height, ChartTheme chartTheme) {
+
+    this(width, height, chartTheme.newInstance(chartTheme));
+  }
+
+  /**
+   * Constructor
+   *
+   * @param chartBuilder
+   */
+  public RadarChart(RadarChartBuilder chartBuilder) {
+
+    this(chartBuilder.width, chartBuilder.height, chartBuilder.chartTheme);
+    setTitle(chartBuilder.title);
+  }
+
+  /**
+   * Add a series for a Radar type chart
+   *
+   * @param seriesName
+   * @param value
+   * @return
+   */
+  public RadarSeries addSeries(String seriesName, double[] values) {
+    return addSeries(seriesName, values, null);
+  }
+  
+  public RadarSeries addSeries(String seriesName, double[] values, String[] toolTips) {
+
+ // Sanity checks
+    sanityCheck(seriesName, values, toolTips);
+
+    
+    RadarSeries series = new RadarSeries(seriesName, values, toolTips);
+
+    seriesMap.put(seriesName, series);
+
+    return series;
+  }
+
+  
+  private void sanityCheck(String seriesName, double[] values, String[] toolTips) {
+
+    if (variableLabels == null) {
+      throw new IllegalArgumentException("Variable labels cannot be null!!!");
+    }
+    
+    if (seriesMap.keySet().contains(seriesName)) {
+      throw new IllegalArgumentException("Series name >" + seriesName + "< has already been used. Use unique names for each series!!!");
+    }
+    if (values == null) {
+      throw new IllegalArgumentException("Values data cannot be null!!!");
+    }
+    if (values.length < variableLabels.length) {
+      throw new IllegalArgumentException("Too few values!!!");
+    }
+    for (double d : values) {
+      if ( d < 0 || d > 1) {
+        throw new IllegalArgumentException("Values must be in [0, 1] range!!!");
+      }
+    }
+    
+    if (toolTips != null && toolTips.length < variableLabels.length) {
+      throw new IllegalArgumentException("Too few tool tips!!!");
+    }
+  }
+  
+  @Override
+  public void paint(Graphics2D g, int width, int height) {
+
+    setWidth(width);
+    setHeight(height);
+
+    setSeriesStyles();
+
+    paintBackground(g);
+
+    plot.paint(g);
+    chartTitle.paint(g);
+    legend.paint(g);
+  }
+
+  /**
+   * set the series color based on theme
+   */
+  private void setSeriesStyles() {
+
+    SeriesColorMarkerLineStyleCycler seriesColorMarkerLineStyleCycler = new SeriesColorMarkerLineStyleCycler(getStyler().getSeriesColors(), getStyler().getSeriesMarkers(), getStyler()
+        .getSeriesLines());
+    for (RadarSeries series : getSeriesMap().values()) {
+
+      SeriesColorMarkerLineStyle seriesColorMarkerLineStyle = seriesColorMarkerLineStyleCycler.getNextSeriesColorMarkerLineStyle();
+
+      if (series.getLineStyle() == null) { // wasn't set manually
+        series.setLineStyle(seriesColorMarkerLineStyle.getStroke());
+      }
+      if (series.getLineColor() == null) { // wasn't set manually
+        series.setLineColor(seriesColorMarkerLineStyle.getColor());
+      }
+      if (series.getFillColor() == null) { // wasn't set manually
+        series.setFillColor(seriesColorMarkerLineStyle.getColor());
+      }
+      if (series.getMarker() == null) { // wasn't set manually
+        series.setMarker(seriesColorMarkerLineStyle.getMarker());
+      }
+      if (series.getMarkerColor() == null) { // wasn't set manually
+        series.setMarkerColor(seriesColorMarkerLineStyle.getColor());
+      }
+    }
+  }
+
+  public String[] getVariableLabels() {
+
+    return variableLabels;
+  }
+  
+  public void setVariableLabels(String[] variableLabels) {
+
+    this.variableLabels = variableLabels;
+  }
+  
+  public RadarRenderStyle getRadarRenderStyle() {
+
+    return radarRenderStyle;
+  }
+  
+  public void setRadarRenderStyle(RadarRenderStyle radarRenderStyle) {
+
+    this.radarRenderStyle = radarRenderStyle;
+  }
+  
+}

--- a/xchart/src/main/java/org/knowm/xchart/RadarChartBuilder.java
+++ b/xchart/src/main/java/org/knowm/xchart/RadarChartBuilder.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2015-2017 Knowm Inc. (http://knowm.org) and contributors.
+ * Copyright 2011-2015 Xeiam LLC (http://xeiam.com) and contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.knowm.xchart;
+
+import org.knowm.xchart.internal.ChartBuilder;
+
+/**
+ * @author timmolter
+ */
+public class RadarChartBuilder extends ChartBuilder<RadarChartBuilder, RadarChart> {
+
+  public RadarChartBuilder() {
+
+  }
+
+  @Override
+  public RadarChart build() {
+
+    return new RadarChart(this);
+  }
+}

--- a/xchart/src/main/java/org/knowm/xchart/RadarSeries.java
+++ b/xchart/src/main/java/org/knowm/xchart/RadarSeries.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright 2015-2017 Knowm Inc. (http://knowm.org) and contributors.
+ * Copyright 2011-2015 Xeiam LLC (http://xeiam.com) and contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.knowm.xchart;
+
+import java.util.List;
+
+import org.knowm.xchart.internal.chartpart.Axis.AxisDataType;
+import org.knowm.xchart.internal.chartpart.RenderableSeries.LegendRenderType;
+import org.knowm.xchart.internal.series.MarkersSeries;
+
+/**
+ * A Series containing Radar data to be plotted on a Chart
+ *
+ * @author timmolter
+ */
+public class RadarSeries extends MarkersSeries {
+
+  LegendRenderType legendRenderType;
+
+  protected double[] values;
+  protected String[] toolTips;
+
+  /**
+   * 
+   * @param toolTips Adds custom tool tips for series. If tool tip is null, it is automatically calculated.
+   */
+
+  public RadarSeries(String name, double[] values, String[] toolTips) {
+
+    super(name, null, null, null);
+    this.values = values;
+    this.toolTips = toolTips;
+  }
+  
+  @Override
+  protected void calculateMinMax() {
+  }
+  
+  public double[] getValues() {
+
+    return values;
+  }
+
+  public void setValues(double[] values) {
+
+    this.values = values;
+  }
+
+  @Override
+  public AxisDataType getAxesType(List<?> data) {
+
+    return AxisDataType.Number;
+  }
+  
+  public void setLegendRenderType(LegendRenderType legendRenderType) {
+
+    this.legendRenderType = legendRenderType;
+  }
+  
+  @Override
+  public LegendRenderType getLegendRenderType() {
+
+    return legendRenderType;
+  }
+
+  public String[] getToolTips() {
+
+    return toolTips;
+  }
+  
+}

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Radar.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotContent_Radar.java
@@ -1,0 +1,349 @@
+/**
+ * Copyright 2015-2017 Knowm Inc. (http://knowm.org) and contributors.
+ * Copyright 2011-2015 Xeiam LLC (http://xeiam.com) and contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.knowm.xchart.internal.chartpart;
+
+import java.awt.Graphics2D;
+import java.awt.Rectangle;
+import java.awt.Shape;
+import java.awt.font.FontRenderContext;
+import java.awt.font.TextLayout;
+import java.awt.geom.AffineTransform;
+import java.awt.geom.Ellipse2D;
+import java.awt.geom.Line2D;
+import java.awt.geom.Path2D;
+import java.awt.geom.Rectangle2D;
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
+import java.util.Map;
+
+import org.knowm.xchart.RadarChart;
+import org.knowm.xchart.RadarChart.RadarRenderStyle;
+import org.knowm.xchart.RadarSeries;
+import org.knowm.xchart.internal.series.Series;
+import org.knowm.xchart.style.RadarStyler;
+import org.knowm.xchart.style.Styler;
+
+public class PlotContent_Radar<ST extends Styler, S extends Series> extends PlotContent_ {
+  private final static int MARGIN = 5;
+  private final RadarStyler styler;
+  private final NumberFormat df = DecimalFormat.getPercentInstance();
+
+  double radarX;
+  double radarY;
+  double xCenter;
+  double yCenter;
+  double xDiameter;
+  double yDiameter;
+  
+  PlotContent_Radar(Chart<RadarStyler, RadarSeries> chart) {
+
+    super(chart);
+    styler = chart.getStyler();
+  }
+
+  protected void calculatePlotVaraiables(double widthCorrection, double heightCorrection) {
+    double fillPercentage = styler.getPlotContentSize();
+    double boundsWidth = getBounds().getWidth();
+    double boundsHeight = getBounds().getHeight();
+
+    double halfBorderPercentage = (1 - fillPercentage) / 2.0;
+    
+    double width;
+    double height;
+    if (styler.isCircular()) {
+      width = Math.min(boundsWidth, boundsHeight);
+      height = width;
+    } else {
+      width = boundsWidth;
+      height = boundsHeight;
+    }
+    double radarW;
+    double radarH;
+
+    radarX = getBounds().getX() + boundsWidth / 2 - width / 2 + halfBorderPercentage * width;
+    radarY = getBounds().getY() + boundsHeight / 2 - height / 2 + halfBorderPercentage * height;
+    radarW = width * fillPercentage;
+    radarH = height * fillPercentage;
+    xDiameter = (radarW  - widthCorrection) / 2;
+    yDiameter = (radarH - heightCorrection) / 2;
+    
+    xCenter = radarX + radarW / 2;
+    yCenter = radarY + radarH / 2;
+  }
+  
+  @Override
+  public void doPaint(Graphics2D g) {
+
+    calculatePlotVaraiables(0, 0);
+    
+    String[] variableLabels = ((RadarChart) chart).getVariableLabels();
+    int variableCount = variableLabels.length;
+
+    Map<String, RadarSeries> map = chart.getSeriesMap();
+    RadarChart radarChart = (RadarChart) chart;
+    
+    double angleForSeries = 360.0 / variableCount;
+    
+    double[] cosArr = new double[variableCount];
+    double[] sinArr = new double[variableCount];
+    
+    Shape[] labelShapes = null;
+    double[] labelX = null;
+    double[] labelY = null;
+    
+    boolean axisTitleVisible = styler.isAxisTitleVisible();
+    if (axisTitleVisible) {
+      labelShapes = new Shape[variableCount];
+      labelX = new double[variableCount]; 
+      labelY = new double[variableCount]; 
+    }
+    
+    double startAngle = styler.getStartAngleInDegrees() + 90;
+    for (int i = 0; i < variableCount; i++) {
+      double radians = Math.toRadians(startAngle);
+      double cos = Math.cos(radians);
+      double sin = Math.sin(radians);
+      cosArr[i] = cos;
+      sinArr[i] = sin;
+      
+      if (axisTitleVisible) {
+        String annotation = variableLabels[i];
+
+        TextLayout textLayout = new TextLayout(annotation, styler.getAxisTitleFont(), new FontRenderContext(null, true, false));
+        Shape shape = textLayout.getOutline(null);
+        labelShapes[i] = shape;
+      }
+      startAngle += angleForSeries;
+    }      
+
+    if (axisTitleVisible) {
+      Rectangle clipBounds = g.getClipBounds();
+
+      double leftEdge = clipBounds.getX() + MARGIN;
+      double rightEdge = clipBounds.getMaxX() - MARGIN * 2;
+
+      double topEdge = clipBounds.getY() + MARGIN;
+      double bottomEdge = clipBounds.getMaxY() - MARGIN * 2;
+      startAngle = styler.getStartAngleInDegrees() + 90;
+      
+      int tryCount = 0;
+
+      int axisTitlePadding = styler.getAxisTitlePadding();
+      for (int i = 0; i < variableCount; i++) {
+        double cos = cosArr[i];
+        double sin = sinArr[i];
+
+        Shape shape = labelShapes[i];
+        Rectangle2D annotationBounds = shape.getBounds2D();
+        double annotationWidth = annotationBounds.getWidth();
+        double annotationHeight = annotationBounds.getHeight();
+
+        double xOffset = xCenter - annotationWidth / 2 + cos * (xDiameter + axisTitlePadding);
+        double yOffset = yCenter + annotationHeight / 2 - sin * (yDiameter + axisTitlePadding);
+        double tx = xOffset - Math.sin(Math.toRadians(startAngle - 90)) * (annotationWidth / 2 + axisTitlePadding);
+        double ty;
+        
+        if ( Math.abs(startAngle - 90) <= 15 || Math.abs(startAngle - 270) <= 15) {
+          ty = yOffset;
+        } else {
+          ty = yOffset + Math.cos(Math.toRadians(startAngle - 90)) * annotationHeight;
+        }
+
+        double x = tx;
+        double y = ty;
+        
+        x = Math.max(x, leftEdge);
+        x = Math.min(x, rightEdge - annotationWidth);
+        y = Math.max(y, topEdge);
+        y = Math.min(y, bottomEdge - annotationHeight);
+        
+        
+        double wcorr = Math.abs(x-tx);
+        double hcorr = Math.abs(y-ty);
+        if (wcorr > 0 || hcorr > 0) {
+          if (tryCount < variableCount) { 
+            if (wcorr > 0) {
+              xDiameter -= Math.abs(wcorr / cos);
+            }
+            if (hcorr > 0) {
+              yDiameter -= Math.abs(hcorr / sin);
+            }
+            
+            if(styler.isCircular()) {
+              xDiameter = Math.min(xDiameter, yDiameter);
+              yDiameter = xDiameter;
+            }
+            
+            tryCount++;
+            i = -1;
+            startAngle = styler.getStartAngleInDegrees() + 90;  
+            continue;
+          }
+        }
+        
+        labelX[i] = x;
+        labelY[i] = y;
+
+        startAngle += angleForSeries;        
+      }
+    }
+    
+    startAngle = styler.getStartAngleInDegrees() + 90;
+    for (int i = 0; i < variableCount; i++) {
+      double cos = cosArr[i];
+      double sin = sinArr[i];
+
+      // draw grid lines
+      if (styler.isPlotGridLinesVisible()) {
+        double xOffset = xCenter + cos * xDiameter;
+        double yOffset = yCenter - sin * yDiameter;
+        Line2D.Double line = new Line2D.Double(xCenter, yCenter, xOffset, yOffset);
+        g.setColor(styler.getPlotGridLinesColor());
+        g.setStroke(styler.getPlotGridLinesStroke());
+        g.draw(line);
+      }
+
+      // draw variable names
+      if (axisTitleVisible){
+        g.setColor(styler.getChartFontColor());
+        g.setFont(styler.getAnnotationsFont());
+        AffineTransform orig = g.getTransform();
+        AffineTransform at = new AffineTransform();
+
+        at.translate(labelX[i], labelY[i]);
+
+        Shape shape = labelShapes[i];
+        g.transform(at);
+        g.fill(shape);
+        g.setTransform(orig);
+      }
+
+      startAngle += angleForSeries;
+    }
+
+    int markCount = styler.getAxisTickMarksCount();
+    
+    if (markCount > 0 && styler.isAxisTicksMarksVisible()) {
+      g.setColor(styler.getAxisTickMarksColor());
+      g.setStroke(styler.getAxisTickMarksStroke());
+      // draw circular marker
+      if (radarChart.getRadarRenderStyle() == RadarRenderStyle.Circle) {
+        Ellipse2D.Double markShape = new Ellipse2D.Double(0, 0, 0, 0);
+        double winc = xDiameter / markCount;
+        double hinc = yDiameter / markCount;
+        
+        double newXd = xDiameter;
+        double newYd = yDiameter;
+        for (int i = 0; i < markCount ; i++) {
+          markShape.width =  newXd * 2;
+          markShape.height =  newYd * 2;
+          markShape.x = xCenter - newXd;
+          markShape.y = yCenter - newYd;
+          g.draw(markShape);
+          newXd -= winc;
+          newYd -= hinc;
+        }
+      } 
+
+      // draw polygon marker
+      if (radarChart.getRadarRenderStyle() == RadarRenderStyle.Polygon) {
+        double winc = xDiameter / markCount;
+        double hinc = yDiameter / markCount;
+        
+        for (int markerInd = 0; markerInd < markCount; markerInd++) {
+          Path2D.Double path = new Path2D.Double();
+          for (int varInd = 0; varInd < variableCount; varInd++) {
+            double cos = cosArr[varInd];
+            double sin = sinArr[varInd];
+            double xOffset = xCenter + cos * (xDiameter - markerInd * winc );
+            double yOffset = yCenter - sin * (yDiameter - markerInd * hinc);
+    
+            if (varInd == 0) {
+              path.moveTo(xOffset, yOffset);
+            } else {
+              path.lineTo(xOffset, yOffset);
+            }
+          }
+          path.closePath();
+          g.draw(path);
+        }
+      }
+    }
+
+    
+    Path2D.Double[] paths = new Path2D.Double[variableCount];
+    for (int i = 0; i < paths.length; i++) {
+      paths[i] = new Path2D.Double();
+    }
+    
+    NumberFormat decimalFormat = (styler.getDecimalPattern() == null) ? df : new DecimalFormat(styler.getDecimalPattern());
+    
+    for (RadarSeries series : map.values()) {
+
+      if (!series.isEnabled()) {
+        continue;
+      }
+
+      double[] values = series.getValues();
+      String[] toolTips = series.getToolTips();
+
+      g.setColor(series.getFillColor());
+      
+      Path2D.Double path = new Path2D.Double();
+      for (int varInd = 0; varInd < variableCount; varInd++) {
+        double cos = cosArr[varInd];
+        double sin = sinArr[varInd];
+
+        double perct = values[varInd];
+        double xOffset = xCenter + cos * (xDiameter * perct);
+        double yOffset = yCenter - sin * (yDiameter * perct);
+
+        if (varInd == 0) {
+          path.moveTo(xOffset, yOffset);
+        } else {
+          path.lineTo(xOffset, yOffset);
+        }
+        
+        // paint marker
+        if (series.getMarker() != null) {
+          g.setColor(series.getMarkerColor());
+          series.getMarker().paint(g, xOffset, yOffset, styler.getMarkerSize());
+        }
+        
+        // add data labels
+        if (chart.getStyler().isToolTipsEnabled()) {
+          String label = null;
+          if (toolTips != null) {
+            label = toolTips[varInd];
+          }
+          if (label == null) {
+            String ystr = decimalFormat.format(perct);
+            label = series.getName() + " (" + variableLabels[varInd] + ": " + ystr + ")";  
+          }
+          chart.toolTips.addData(xOffset, yOffset, label);
+        }
+
+      }
+      path.closePath();
+      g.setColor(series.getLineColor());
+      g.draw(path);
+      g.setColor(series.getFillColor());
+      g.fill(path);
+    }
+  }
+
+}

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotSurface_Radar.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/PlotSurface_Radar.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2015-2017 Knowm Inc. (http://knowm.org) and contributors.
+ * Copyright 2011-2015 Xeiam LLC (http://xeiam.com) and contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.knowm.xchart.internal.chartpart;
+
+import java.awt.Graphics2D;
+import java.awt.Shape;
+import java.awt.geom.Rectangle2D;
+
+import org.knowm.xchart.RadarSeries;
+import org.knowm.xchart.internal.series.Series;
+import org.knowm.xchart.style.RadarStyler;
+import org.knowm.xchart.style.Styler;
+
+/**
+ * Draws the plot background and the plot border
+ *
+ * @author timmolter
+ */
+public class PlotSurface_Radar<ST extends Styler, S extends Series> extends PlotSurface_ {
+
+  private final RadarStyler stylerRadar;
+
+  /**
+   * Constructor
+   *
+   * @param chart
+   */
+  PlotSurface_Radar(Chart<RadarStyler, RadarSeries> chart) {
+
+    super(chart);
+    this.stylerRadar = chart.getStyler();
+  }
+
+  @Override
+  public void paint(Graphics2D g) {
+
+    Rectangle2D bounds = getBounds();
+
+    // paint plot background
+    Shape rect = new Rectangle2D.Double(bounds.getX(), bounds.getY(), bounds.getWidth(), bounds.getHeight());
+    g.setColor(stylerRadar.getPlotBackgroundColor());
+    g.fill(rect);
+
+    // paint plot border
+    if (stylerRadar.isPlotBorderVisible()) {
+      g.setColor(stylerRadar.getPlotBorderColor());
+      // g.setStroke(getChartPainter().getstyler().getAxisTickMarksStroke());
+      g.draw(rect);
+    }
+  }
+}

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Plot_Radar.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Plot_Radar.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright 2015-2017 Knowm Inc. (http://knowm.org) and contributors.
+ * Copyright 2011-2015 Xeiam LLC (http://xeiam.com) and contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.knowm.xchart.internal.chartpart;
+
+import java.awt.Graphics2D;
+import java.awt.geom.Rectangle2D;
+
+import org.knowm.xchart.RadarSeries;
+import org.knowm.xchart.internal.series.Series;
+import org.knowm.xchart.style.RadarStyler;
+import org.knowm.xchart.style.Styler;
+import org.knowm.xchart.style.Styler.LegendPosition;
+
+/**
+ * @author timmolter
+ */
+public class Plot_Radar<ST extends Styler, S extends Series> extends Plot_ {
+
+  /**
+   * Constructor
+   *
+   * @param chart
+   */
+  public Plot_Radar(Chart<RadarStyler, RadarSeries> chart) {
+
+    super(chart);
+    this.plotContent = new PlotContent_Radar<RadarStyler, RadarSeries>(chart);
+    this.plotSurface = new PlotSurface_Radar<RadarStyler, RadarSeries>(chart);
+  }
+
+  @Override
+  public void paint(Graphics2D g) {
+
+    // calculate bounds
+    double xOffset = chart.getStyler().getChartPadding();
+
+    // double yOffset = chart.getChartTitle().getBounds().getHeight() + 2 * chart.getStyler().getChartPadding();
+    double yOffset = chart.getChartTitle().getBounds().getHeight() + chart.getStyler().getChartPadding();
+
+    double width =
+
+        chart.getWidth()
+
+            - (chart.getStyler().getLegendPosition() == LegendPosition.OutsideE ? chart.getLegend().getBounds().getWidth() : 0)
+
+            - 2 * chart.getStyler().getChartPadding()
+
+            - (chart.getStyler().getLegendPosition() == LegendPosition.OutsideE && chart.getStyler().isLegendVisible() ? chart.getStyler().getChartPadding() : 0);
+
+    double height = chart.getHeight() - chart.getChartTitle().getBounds().getHeight() - 2 * chart.getStyler().getChartPadding();
+
+    this.bounds = new Rectangle2D.Double(xOffset, yOffset, width, height);
+
+    super.paint(g);
+  }
+}

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/ToolTips.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/ToolTips.java
@@ -144,7 +144,7 @@ public class ToolTips implements MouseMotionListener {
   /**
    * Adds a data with label with coordinates (xOffset, yOffset). This point will be highlighted with a circle centering (xOffset, yOffset)
    */
-  private void addData(double xOffset, double yOffset, String label) {
+  public void addData(double xOffset, double yOffset, String label) {
 
     DataPoint dp = new DataPoint(xOffset, yOffset, label);
     dataPointList.add(dp);

--- a/xchart/src/main/java/org/knowm/xchart/style/RadarStyler.java
+++ b/xchart/src/main/java/org/knowm/xchart/style/RadarStyler.java
@@ -1,0 +1,245 @@
+/**
+ * Copyright 2015-2017 Knowm Inc. (http://knowm.org) and contributors.
+ * Copyright 2011-2015 Xeiam LLC (http://xeiam.com) and contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.knowm.xchart.style;
+
+import java.awt.Color;
+import java.awt.Font;
+import java.awt.Stroke;
+
+/**
+ * @author timmolter
+ */
+public class RadarStyler extends Styler {
+
+  private boolean isCircular;
+  private double startAngleInDegrees;
+  
+  // Chart Plot Area ///////////////////////////////
+  // main lines
+  private boolean plotGridLinesVisible;
+  private Color plotGridLinesColor;
+  private Stroke plotGridLinesStroke;
+
+  // helper tick lines
+  private boolean axisTicksMarksVisible;
+  private Color axisTickMarksColor;
+  private Stroke axisTickMarksStroke;
+  private int axisTickMarksCount = 5;
+
+  // variable labels
+  private boolean axisTitleVisible;
+  private Font axisTitleFont;
+  private int axisTitlePadding;
+
+  
+  private int markerSize;
+
+  public RadarStyler() {
+
+    this.setAllStyles();
+    super.setAllStyles();
+  }
+
+  @Override
+  void setAllStyles() {
+
+    this.isCircular = theme.isCircular();
+    this.startAngleInDegrees = theme.getStartAngleInDegrees();
+
+    // Annotations ////////////////////////////////
+    this.hasAnnotations = true;
+
+    this.markerSize = theme.getMarkerSize();
+    
+    // Chart Plot Area ///////////////////////////////
+    this.plotGridLinesVisible = theme.isPlotGridLinesVisible();
+    this.plotGridLinesColor = theme.getPlotGridLinesColor();
+    this.plotGridLinesStroke = theme.getPlotGridLinesStroke();
+
+    
+    this.axisTickMarksColor = theme.getAxisTickMarksColor();
+    this.axisTickMarksStroke = theme.getAxisTickMarksStroke();
+    this.axisTicksMarksVisible = theme.isAxisTicksMarksVisible();
+    
+    
+    this.axisTitleVisible = theme.isXAxisTitleVisible() || theme.isYAxisTitleVisible();
+    this.axisTitleFont = theme.getAxisTitleFont();
+    this.axisTitlePadding = theme.getAxisTitlePadding();
+    
+  }
+
+  public boolean isCircular() {
+
+    return isCircular;
+  }
+
+  /**
+   * Sets whether or not the radar chart is forced to be circular. Otherwise it's shape is oval, matching the containing plot.
+   *
+   * @param isCircular
+   */
+  public RadarStyler setCircular(boolean isCircular) {
+
+    this.isCircular = isCircular;
+    return this;
+  }
+
+  public double getStartAngleInDegrees() {
+
+    return startAngleInDegrees;
+  }
+
+  /**
+   * Sets the start angle in degrees. Zero degrees is straight up.
+   *
+   * @param startAngleInDegrees
+   */
+  public RadarStyler setStartAngleInDegrees(double startAngleInDegrees) {
+
+    this.startAngleInDegrees = startAngleInDegrees;
+    return this;
+  }
+
+  /**
+   * Set the theme the styler should use
+   *
+   * @param theme
+   */
+  public RadarStyler setTheme(Theme theme) {
+
+    this.theme = theme;
+    super.setAllStyles();
+    return this;
+  }
+
+  /**
+   * Sets the size of the markers (in pixels)
+   *
+   * @param markerSize
+   */
+  public RadarStyler setMarkerSize(int markerSize) {
+
+    this.markerSize = markerSize;
+    return this;
+  }
+
+  public int getMarkerSize() {
+
+    return markerSize;
+  }
+  
+  public boolean isPlotGridLinesVisible() {
+
+    return plotGridLinesVisible;
+  }
+  
+  public void setPlotGridLinesVisible(boolean plotGridLinesVisible) {
+
+    this.plotGridLinesVisible = plotGridLinesVisible;
+  }
+  
+  
+  public Color getPlotGridLinesColor() {
+
+    return plotGridLinesColor;
+  }
+  
+  public void setPlotGridLinesColor(Color plotGridLinesColor) {
+
+    this.plotGridLinesColor = plotGridLinesColor;
+  }
+  
+  public Stroke getPlotGridLinesStroke() {
+
+    return plotGridLinesStroke;
+  }
+  
+  public void setPlotGridLinesStroke(Stroke plotGridLinesStroke) {
+
+    this.plotGridLinesStroke = plotGridLinesStroke;
+  }
+
+  public boolean isAxisTicksMarksVisible() {
+
+    return axisTicksMarksVisible;
+  }
+  
+  public void setAxisTicksMarksVisible(boolean axisTicksMarksVisible) {
+
+    this.axisTicksMarksVisible = axisTicksMarksVisible;
+  }
+  
+  public Color getAxisTickMarksColor() {
+
+    return axisTickMarksColor;
+  }
+  
+  public void setAxisTickMarksColor(Color axisTickMarksColor) {
+
+    this.axisTickMarksColor = axisTickMarksColor;
+  }
+  
+  public Stroke getAxisTickMarksStroke() {
+
+    return axisTickMarksStroke;
+  }
+  
+  public void setAxisTickMarksStroke(Stroke axisTickMarksStroke) {
+
+    this.axisTickMarksStroke = axisTickMarksStroke;
+  }
+
+  public boolean isAxisTitleVisible() {
+
+    return axisTitleVisible;
+  }
+  
+  public void setAxisTitleVisible(boolean axisTitleVisible) {
+
+    this.axisTitleVisible = axisTitleVisible;
+  }
+  
+  public Font getAxisTitleFont() {
+
+    return axisTitleFont;
+  }
+  
+  public void setAxisTitleFont(Font axisTitleFont) {
+
+    this.axisTitleFont = axisTitleFont;
+  }
+  
+  public int getAxisTitlePadding() {
+
+    return axisTitlePadding;
+  }
+  
+  public void setAxisTitlePadding(int axisTitlePadding) {
+
+    this.axisTitlePadding = axisTitlePadding;
+  }
+
+  public int getAxisTickMarksCount() {
+
+    return axisTickMarksCount;
+  }
+  
+  public void setAxisTickMarksCount(int axisTickMarksCount) {
+
+    this.axisTickMarksCount = axisTickMarksCount;
+  }
+}


### PR DESCRIPTION
Added a new chart type: radar #189  

- New chart is created by copying PieChart.
- (+) Polygon/Circle render types
- (+) Custom tool tips
- (+) Circular /non circular rendering
- (-) No annotations

Usage:
- Create a RadarChart
- Set variable names before adding any series: `chart.setVariableLabels(new String[] {"Sales", "Marketting", "Development", "Customer Support", "Information Technology", "Administration" });`
- Add series. Each series must have at least variable count numbers. Each number in the series must be in range [0, 1]
- Custom tool tips can be given when adding series. 

![image](https://user-images.githubusercontent.com/6737748/28462018-fbb24fb6-6e21-11e7-868d-560b1f73eaa3.png)

