### PR TITLE
Added workaround for x-y axis change

### DIFF
--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue136_1.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForIssue136_1.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright 2015-2017 Knowm Inc. (http://knowm.org) and contributors.
+ * Copyright 2011-2015 Xeiam LLC (http://xeiam.com) and contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.knowm.xchart.standalone.issues;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import org.knowm.xchart.CategoryChart;
+import org.knowm.xchart.CategoryChartBuilder;
+import org.knowm.xchart.SwingWrapper;
+import org.knowm.xchart.style.Styler.LegendPosition;
+
+/**
+ * Create a Chart matrix
+ *
+ * @author timmolter
+ */
+public class TestForIssue136_1 {
+
+  public static void main(String[] args) {
+    int[][] sizes = { {800, 600}, {800, 800}, {800,900}}; 
+    
+    ArrayList<CategoryChart> charts = new ArrayList<CategoryChart>();
+    for (int[] is : sizes) {
+      CategoryChart chart = getChart(is[0], is[1]);
+      chart.getStyler().setXAxisLabelRotation(90);
+      //chart.getStyler().setAxisTitlesVisible(false);
+      chart.getStyler().setYAxisTicksVisible(false);
+      chart.getStyler().setHasAnnotations(false);
+      chart.getStyler().setLegendVisible(false);
+
+      chart.setVertical(true);
+      //chart.getStyler().setYAxisTitleVisible(false);
+      charts.add(chart);
+      
+      new SwingWrapper<CategoryChart>(chart).displayChart(is[0] + "x" + is[1]);
+    }
+
+    new SwingWrapper<CategoryChart>(charts).displayChartMatrix();
+  }
+
+  
+  public static CategoryChart getChart(int width, int height) {
+
+    // Create Chart
+    CategoryChart chart = new CategoryChartBuilder().width(width).height(height).title("Score Histogram").xAxisTitle("Score").yAxisTitle("Number").build();
+
+    // Customize Chart
+    chart.getStyler().setLegendPosition(LegendPosition.InsideNW);
+    chart.getStyler().setHasAnnotations(true);
+    chart.getStyler().setPlotGridLinesVisible(false);
+
+    // Series
+    chart.addSeries("test 1", Arrays.asList(0, 1, 2, 3, 4), Arrays.asList(4, 5, 9, 6, 5));
+
+    return chart;
+  }
+
+  
+}

--- a/xchart/src/main/java/org/knowm/xchart/XChartPanel.java
+++ b/xchart/src/main/java/org/knowm/xchart/XChartPanel.java
@@ -26,6 +26,7 @@ import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
 import java.awt.event.MouseMotionListener;
+import java.awt.geom.AffineTransform;
 import java.io.File;
 import java.io.IOException;
 
@@ -117,7 +118,21 @@ public class XChartPanel<T extends Chart> extends JPanel {
     super.paintComponent(g);
 
     Graphics2D g2d = (Graphics2D) g.create();
-    chart.paint(g2d, getWidth(), getHeight());
+    
+    if (chart.isVertical()) {
+      AffineTransform orig = g2d.getTransform();
+      int newW = getHeight();
+      int newH = getWidth();
+      int rotatePoint = newH / 2;
+
+      //g2d.rotate(Math.PI/2, rotatePoint, rotatePoint);
+      g2d.rotate(Math.PI/2, rotatePoint, rotatePoint);
+      chart.paint(g2d, newW, newH);
+      
+      g2d.setTransform(orig);
+    } else {
+      chart.paint(g2d, getWidth(), getHeight());
+    }
     g2d.dispose();
   }
 
@@ -389,5 +404,4 @@ public class XChartPanel<T extends Chart> extends JPanel {
       }
     }
   }
-
 }

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Chart.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Chart.java
@@ -60,6 +60,8 @@ public abstract class Chart<ST extends Styler, S extends Series> {
 
   protected final Map<String, S> seriesMap = new LinkedHashMap<String, S>();
 
+  private boolean vertical = false;
+
   /**
    * Constructor
    *
@@ -226,6 +228,16 @@ public abstract class Chart<ST extends Styler, S extends Series> {
   Format getYAxisFormat() {
 
     return axisPair.getYAxis().getAxisTickCalculator().getAxisFormat();
+  }
+
+  public boolean isVertical() {
+
+    return vertical;
+  }
+  
+  public void setVertical(boolean vertical) {
+
+    this.vertical = vertical;
   }
 
 }

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Legend_.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Legend_.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import org.knowm.xchart.internal.chartpart.RenderableSeries.LegendRenderType;
 import org.knowm.xchart.internal.series.Series;
 import org.knowm.xchart.style.Styler;
+import org.knowm.xchart.style.Styler.LegendPosition;
 
 /**
  * @author timmolter
@@ -125,16 +126,23 @@ public abstract class Legend_<ST extends Styler, S extends Series> implements Ch
         break;
     }
 
-    // draw legend box background and border
-    Shape rect = new Rectangle2D.Double(xOffset, yOffset, bounds.getWidth(), height);
+    Rectangle2D rect = new Rectangle2D.Double(xOffset, yOffset, bounds.getWidth(), height);
+    AffineTransform orig = null;
+    if (chart.isVertical()) {
+      orig = g.getTransform();
+      rotateLegend(g, rect, chart.getStyler().getLegendPosition());
+    }
     g.setColor(chart.getStyler().getLegendBackgroundColor());
     g.fill(rect);
     g.setStroke(SOLID_STROKE);
     g.setColor(chart.getStyler().getLegendBorderColor());
     g.draw(rect);
-
+    
     doPaint(g);
 
+    if (chart.isVertical()) {
+      g.setTransform(orig);
+    }
     // bounds
 //    bounds = new Rectangle2D.Double(xOffset, yOffset, bounds.getWidth(), bounds.getHeight());
     // g.setColor(Color.blue);
@@ -343,5 +351,55 @@ public abstract class Legend_<ST extends Styler, S extends Series> implements Ch
     } else {
       return getBoundsHintHorizontal(); // Actually, the only information contained in this bounds is the width and height.
     }
+  }
+  
+  protected void rotateLegend(Graphics2D g2d, Rectangle2D legendBounds, LegendPosition legendPosition) {
+    double xOffset = 0;
+    double yOffset = 0;
+    double xstart = legendBounds.getX();
+    double ystart = legendBounds.getY();
+    double width = legendBounds.getWidth();
+    double height = legendBounds.getHeight();
+
+    switch (legendPosition) {
+    case OutsideE:
+      xOffset = xstart - ystart + width - height;
+      yOffset = xstart + ystart + width - height;
+      break;
+    case InsideNW:
+      xOffset = xstart - ystart;
+      yOffset = xstart + ystart + width;
+      break;
+    case InsideNE:
+      xOffset = xstart - ystart + width - height;
+      yOffset = xstart + ystart + width;
+      break;
+    case InsideSE:
+      xOffset = xstart - ystart + width - height;
+      yOffset = xstart + ystart + height;
+      break;
+    case InsideSW:
+      xOffset = xstart - ystart;
+      yOffset = xstart + ystart + height;
+      break;
+    case InsideN:
+      xOffset = xstart - ystart + height;
+      yOffset = xstart + ystart + width;
+      break;
+    case InsideS:
+      xOffset = xstart - ystart + height;
+      yOffset = xstart + ystart + height;
+      break;
+    case OutsideS:
+      xOffset = xstart - ystart + height;
+      yOffset = xstart + ystart + height;
+      break;
+
+    default:
+      break;
+    }
+
+    g2d.translate(xOffset, yOffset);
+    g2d.rotate(-Math.PI / 2);
   }
 }


### PR DESCRIPTION
Added a simple workaround for x-y axis change ( #136 ). This workaround just rotates Graphics2D object before drawing the graph. Basic functionality works on all charts, but additional functionality (labels, legend, tool tips, etc) is rotated as well. 
It can be used if additional functionality is not needed.


![image](https://user-images.githubusercontent.com/6737748/28524529-8e1c3cf4-7089-11e7-9cfd-374d937cae0a.png)

![image](https://user-images.githubusercontent.com/6737748/28524611-e825eb78-7089-11e7-8caf-78fc8c021aac.png)

![image](https://user-images.githubusercontent.com/6737748/28524756-7cc2edbc-708a-11e7-8ef4-8f070df70ebe.png)



