### PR TITLE
Changed tooltip activation area & bar width on OHLC Chart

### DIFF
--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/ohlc/OHLCChart01.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/ohlc/OHLCChart01.java
@@ -24,6 +24,7 @@ import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 
@@ -57,13 +58,16 @@ public class OHLCChart01 implements ExampleChart<OHLCChart> {
 
   public static void populateData(Date startDate, double startPrice, int count, List<Date> xData,
                                   List<Double> openData, List<Double> highData, List<Double> lowData, List<Double> closeData) {
-
+    Calendar cal = Calendar.getInstance();
+    cal.setTime(startDate);
     double data = startPrice;
     for (int i = 1; i <= count; i++) {
 
       // add 1 day
-      startDate = new Date(startDate.getTime() + (1 * 1000 * 60 * 60 * 24));
-      xData.add(startDate);
+      //startDate = new Date(startDate.getTime() + (1 * 1000 * 60 * 60 * 24));
+      //xData.add(startDate);
+      cal.add(Calendar.DATE, 1);
+      xData.add(cal.getTime());
 
       double previous = data;
 
@@ -109,8 +113,9 @@ public class OHLCChart01 implements ExampleChart<OHLCChart> {
 
     populateData(xData, openData, highData, lowData, closeData);
 
+    xData = null;
     chart.addSeries("Series", xData, openData, highData, lowData, closeData).setRenderStyle(OHLCSeries.OHLCSeriesRenderStyle.HiLo);
-
+    chart.getStyler().setToolTipsEnabled(true);
     return chart;
   }
 

--- a/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/ohlc/OHLCChart02.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/demo/charts/ohlc/OHLCChart02.java
@@ -59,9 +59,9 @@ public class OHLCChart02 implements ExampleChart<OHLCChart> {
     List<Double> closeData = new ArrayList<Double>();
 
     OHLCChart01.populateData(xData, openData, highData, lowData, closeData);
-
+    xData = null;
     chart.addSeries("Series", xData, openData, highData, lowData, closeData);
-
+    chart.getStyler().setToolTipsEnabled(true);
     return chart;
   }
 


### PR DESCRIPTION
#214 
Changed tooltip activation area.
Changed how bar width is calculated (//TODO on PlotContent_OHLC class). 

By the way when xData is changed from Date to double, x tick marks aligned better (maybe -lineWidth/2 would make them better).  See screenshot below:
![image](https://user-images.githubusercontent.com/6737748/30547981-8fe2006e-9c99-11e7-9551-280da463bc49.png)

