### PR TITLE
Added custom axis tick calculator.

### DIFF
--- a/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForTickCalculatorCustom.java
+++ b/xchart-demo/src/main/java/org/knowm/xchart/standalone/issues/TestForTickCalculatorCustom.java
@@ -1,0 +1,119 @@
+/**
+ * Copyright 2015-2017 Knowm Inc. (http://knowm.org) and contributors.
+ * Copyright 2011-2015 Xeiam LLC (http://xeiam.com) and contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.knowm.xchart.standalone.issues;
+
+import java.awt.Dimension;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+import javax.swing.JFrame;
+
+import org.knowm.xchart.CategorySeries;
+import org.knowm.xchart.SwingWrapper;
+import org.knowm.xchart.XYChart;
+import org.knowm.xchart.XYSeries;
+import org.knowm.xchart.demo.charts.area.AreaChart01;
+import org.knowm.xchart.demo.charts.bar.BarChart06;
+import org.knowm.xchart.demo.charts.date.DateChart05;
+import org.knowm.xchart.internal.chartpart.Chart;
+
+/**
+ * Create a Chart matrix
+ *
+ * @author timmolter
+ */
+public class TestForTickCalculatorCustom {
+
+  public static void main(String[] args) {
+    List<Chart> charts = new ArrayList<Chart>();
+
+    charts.add(new AreaChart01().getChart());
+    charts.add(new BarChart06().getChart());
+    charts.add(new DateChart05().getChart());
+
+    {
+      XYChart chart = new AreaChart01().getChart();
+      Map<Double, Object> xMarkMap = new TreeMap<Double, Object>();
+      xMarkMap.put(0.0, "zero");
+      xMarkMap.put(3.5, "3.5");
+      xMarkMap.put(5.0, " ");
+      xMarkMap.put(9.0, "nine");
+
+      Map<Double, Object> yMarkMap = new TreeMap<Double, Object>();
+      yMarkMap.put(1.0, "max c");
+      yMarkMap.put(6.0, "max b");
+      yMarkMap.put(9.0, "max a");
+      
+      chart.setXAxisTickLocationLabelMap(xMarkMap);
+      chart.setYAxisTickLocationLabelMap(yMarkMap);
+      chart.setTitle("AreaChart01 - custom x&y axis labels");
+      charts.add(chart);
+    }
+    {
+      // issue 171
+      // Is there a way to display the labels, say, for every 5 x-value
+      Chart chart = new BarChart06().getChart();
+      
+      CategorySeries series = (CategorySeries) chart.getSeriesMap().get("histogram 1");
+      List<?> xData = (List<?>) series.getXData();
+      Map<Double, Object> xMarkMap = new TreeMap<Double, Object>();
+      // for category charts 0 means first category, 1 means second category, ...
+      
+      for (int i = 0; i < xData.size(); i+= 5) {
+        xMarkMap.put((double)i, xData.get(i));
+      }
+      
+      chart.setXAxisTickLocationLabelMap(xMarkMap);
+      chart.setTitle("Score Histogram - x axis labels on each 5th category");
+      charts.add(chart);
+    }
+    {
+      // issue 159 & 132
+      // The graph however displays labels on the x axis inbetween these points. Doesn't seem to be possible to prevent this
+      XYChart chart = new DateChart05().getChart();
+      chart.setTitle("Day scale - x axis labels on every data point");
+      
+      XYSeries xySeries = chart.getSeriesMap().get("blah");
+      double[] xData = xySeries.getXData();
+      Map<Double, Object> xMarkMap = new TreeMap<Double, Object>();
+      SimpleDateFormat sdf = new SimpleDateFormat("MM-dd");
+      
+      for (double d : xData) {
+        Date date = new Date((long)d);
+        String label = sdf.format(date);
+        xMarkMap.put(d, label);
+      }
+      
+      chart.setXAxisTickLocationLabelMap(xMarkMap);
+      charts.add(chart);
+    }
+    
+    for (Chart chart : charts) {
+      chart.getStyler().setToolTipsEnabled(true);
+    }
+    JFrame frame = new SwingWrapper<Chart>(charts).displayChartMatrix();
+    Dimension preferredSize = new Dimension(1920, 1000);
+    frame.setPreferredSize(preferredSize);
+    frame.setSize(preferredSize);
+    frame.setVisible(true);
+  }
+
+}

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Axis.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Axis.java
@@ -24,6 +24,7 @@ import java.awt.font.TextLayout;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.Rectangle2D;
 import java.util.List;
+import java.util.Map;
 
 import org.knowm.xchart.internal.series.AxesChartSeries;
 import org.knowm.xchart.internal.series.AxesChartSeriesCategory;
@@ -375,6 +376,21 @@ public class Axis<ST extends AxesChartStyler, S extends AxesChartSeries> impleme
   }
 
   private AxisTickCalculator_ getAxisTickCalculator(double workingSpace) {
+    
+    // check if a custom tick label map is present
+	Map<Double, Object> map = chart.getAxisTickLocationLabelMap(getDirection(), yIndex);
+    if (map != null) {
+      
+      if (getDirection() == Direction.X && axesChartStyler instanceof CategoryStyler) {
+        AxesChartSeriesCategory axesChartSeries = (AxesChartSeriesCategory) chart.getSeriesMap().values().iterator().next();
+        List<?> categories = (List<?>) axesChartSeries.getXData();
+        DataType axisType = chart.getAxisPair().getXAxis().getDataType();
+        
+        return new AxisTickCalculator_Custom(getDirection(), workingSpace, axesChartStyler, map, axisType, categories.size());
+      }
+        
+      return new AxisTickCalculator_Custom(getDirection(), workingSpace, min, max, axesChartStyler, map); 
+    }
 
     // X-Axis
     if (getDirection() == Direction.X) {

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxisTickCalculator_Custom.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/AxisTickCalculator_Custom.java
@@ -1,0 +1,129 @@
+/**
+ * Copyright 2015-2017 Knowm Inc. (http://knowm.org) and contributors.
+ * Copyright 2011-2015 Xeiam LLC (http://xeiam.com) and contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.knowm.xchart.internal.chartpart;
+
+import java.text.SimpleDateFormat;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.knowm.xchart.internal.Utils;
+import org.knowm.xchart.internal.chartpart.Axis.Direction;
+import org.knowm.xchart.internal.series.Series;
+import org.knowm.xchart.style.AxesChartStyler;
+
+/**
+ * This class encapsulates the logic to generate the axis tick mark and axis tick label data for rendering the axis ticks for given values&labels
+ *
+ */
+class AxisTickCalculator_Custom extends AxisTickCalculator_ {
+
+  /**
+   * Constructor
+   *
+   * @param axisDirection
+   * @param workingSpace
+   * @param minValue
+   * @param maxValue
+   * @param styler
+   * @param markMap 
+   */
+  public AxisTickCalculator_Custom(Direction axisDirection, double workingSpace, double minValue, double maxValue, AxesChartStyler styler, Map<Double, Object> markMap) {
+
+    super(axisDirection, workingSpace, minValue, maxValue, styler);
+    axisFormat = new NumberFormatter(styler, axisDirection, minValue, maxValue);
+    calculate(markMap);
+  }
+  
+  public AxisTickCalculator_Custom(Direction axisDirection, double workingSpace, AxesChartStyler styler, Map<Double, Object> markMap, Series.DataType axisType, int categoryCount) {
+    
+    super(axisDirection, workingSpace, Double.NaN, Double.NaN, styler);
+    // set up String formatters that may be encountered
+    if (axisType == Series.DataType.String) {
+      axisFormat = new StringFormatter();
+    } else if (axisType == Series.DataType.Number) {
+      axisFormat = new NumberFormatter(styler, axisDirection, minValue, maxValue);
+    } else if (axisType == Series.DataType.Date) {
+      if (styler.getDatePattern() == null) {
+        throw new RuntimeException("You need to set the Date Formatting Pattern!!!");
+      }
+      SimpleDateFormat simpleDateformat = new SimpleDateFormat(styler.getDatePattern(), styler.getLocale());
+      simpleDateformat.setTimeZone(styler.getTimezone());
+      axisFormat = simpleDateformat;
+    }
+
+    calculateForCategory(markMap, categoryCount);
+  }
+
+  private void calculate(Map<Double, Object> locationLabelMap) {
+
+    // a check if all axis data are the exact same values
+    if (minValue == maxValue) {
+      String label = locationLabelMap.isEmpty() ? " " : locationLabelMap.values().iterator().next().toString();
+      tickLabels.add(label);
+      tickLocations.add(workingSpace / 2.0);
+      return;
+    }
+
+    // tick space - a percentage of the working space available for ticks
+    double tickSpace = styler.getPlotContentSize() * workingSpace; // in plot space
+
+    // this prevents an infinite loop when the plot gets sized really small.
+    if (tickSpace < styler.getXAxisTickMarkSpacingHint()) {
+      return;
+    }
+
+    // where the tick should begin in the working space in pixels
+    double margin = Utils.getTickStartOffset(workingSpace, tickSpace); // in plot space double gridStep = getGridStepForDecimal(tickSpace);
+
+    // generate all tickLabels and tickLocations from the first to last position
+    for (Entry<Double, Object> entry : locationLabelMap.entrySet()) {
+      Object value = entry.getValue();
+      String tickLabel = value == null ? " " : value.toString();
+      tickLabels.add(tickLabel);
+
+      double tickLabelPosition = margin + ((entry.getKey().doubleValue() - minValue) / (maxValue - minValue) * tickSpace);
+      tickLocations.add(tickLabelPosition);
+    }
+  }
+  
+  private void calculateForCategory(Map<Double, Object> locationLabelMap, int categoryCount) {
+
+    // tick space - a percentage of the working space available for ticks
+    double tickSpace = styler.getPlotContentSize() * workingSpace; // in plot space
+    // System.out.println("workingSpace: " + workingSpace);
+    // System.out.println("tickSpace: " + tickSpace);
+
+    // where the tick should begin in the working space in pixels
+    double margin = Utils.getTickStartOffset(workingSpace, tickSpace);
+    // System.out.println("Margin: " + margin);
+
+    // generate all tickLabels and tickLocations from the first to last position
+    double gridStep = (tickSpace / categoryCount);
+    // System.out.println("GridStep: " + gridStep);
+    double firstPosition = gridStep / 2.0;
+
+    for (Entry<Double, Object> entry : locationLabelMap.entrySet()) {
+      Object value = entry.getValue();
+      String tickLabel = value == null ? " " : value.toString();
+      tickLabels.add(tickLabel);
+
+      double tickLabelPosition = margin + firstPosition + gridStep * entry.getKey().doubleValue();
+      tickLocations.add(tickLabelPosition);
+    }
+  }
+
+}

--- a/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Chart.java
+++ b/xchart/src/main/java/org/knowm/xchart/internal/chartpart/Chart.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import org.knowm.xchart.internal.chartpart.Axis.Direction;
 import org.knowm.xchart.internal.series.Series;
 import org.knowm.xchart.style.Styler;
 
@@ -48,6 +49,7 @@ public abstract class Chart<ST extends Styler, S extends Series> {
   private String xAxisTitle = "";
   private String yAxisTitle = "";
   private HashMap<Integer, String> yAxisGroupTitleMap = new HashMap<Integer, String>();
+  private HashMap<String, Map<Double, Object>> axisTickLocationLabelMap = new HashMap<String, Map<Double, Object>>();
 
   /**
    * Chart Parts
@@ -227,5 +229,25 @@ public abstract class Chart<ST extends Styler, S extends Series> {
 
     return axisPair.getYAxis().getAxisTickCalculator().getAxisFormat();
   }
+  
+  public void setXAxisTickLocationLabelMap(Map<Double, Object> axisTickValueLabelMap) {
+    
+    axisTickLocationLabelMap.put("X0", axisTickValueLabelMap);
+  }
 
+  public void setYAxisTickLocationLabelMap(Map<Double, Object> axisTickValueLabelMap) {
+    
+    axisTickLocationLabelMap.put("Y0", axisTickValueLabelMap);
+  }
+  
+  public void setYAxisTickLocationLabelMap(Map<Double, Object> axisTickValueLabelMap, int yAxisGroup) {
+    
+    axisTickLocationLabelMap.put("Y" + yAxisGroup, axisTickValueLabelMap);
+  }
+  
+  public Map<Double, Object> getAxisTickLocationLabelMap(Direction direction, int yIndex) {
+
+    return axisTickLocationLabelMap.get(direction.name() + yIndex);
+    
+  }
 }


### PR DESCRIPTION
Custom tick calculator draws ticks & labels given by the user.
User gives a map containing x -> label mappings:
-  x : value where the tick will be drawn (this value is in xData space, not in pixel space)
For category charts x is index of the category (0 means first category).
-  label: Tick label. If it is null, tick will be generated with a " " label

Custom tick calculator solves following issues:
- #171: Is there a way to display the labels, say, for every 5 x-value (category charts)
- #159: Too many value labels on x axis  
- #132: Only show x axis ticks that have series data

Note:
- Custom tick calculator does not check for overlapping labels. User is responsible for preventing overlapping.
- Ticks can be created unevenly. If evenly ticks required, user must supply evenly x->label mappings (some labels can be empty)
 
See TestForTickCalculatorCustom.java for example code.
- First row contains default examples
- Second row contains custom axis ticks & labels

![image](https://user-images.githubusercontent.com/6737748/30630920-20ed930a-9deb-11e7-91cb-cf322d040670.png)
