### PR TITLE
Export Directory Selection

### DIFF
--- a/xchart/src/main/java/org/knowm/xchart/XChartPanel.java
+++ b/xchart/src/main/java/org/knowm/xchart/XChartPanel.java
@@ -246,7 +246,7 @@ public class XChartPanel<T extends Chart> extends JPanel {
 
     if (fileChooser.showSaveDialog(null) == JFileChooser.APPROVE_OPTION) {
 
-      File theFileToSave = fileChooser.getCurrentDirectory();
+      File theFileToSave = fileChooser.getSelectedFile();
       try {
         CSVExporter.writeCSVColumns((XYChart) chart, theFileToSave.getCanonicalPath() + File.separatorChar);
       } catch (IOException e) {


### PR DESCRIPTION
When using "fileChooser.getCurrentDirectory" the files will be saved in the root folder of the selected one. Example: Actually selected: ..\User\Documents --> files will be saved at ..\User
.getSelectedFiles() will fix that